### PR TITLE
Fixed invalid base64 for vehicle ID

### DIFF
--- a/api/src/main/java/uk/gov/dvsa/mot/security/ParamObfuscator.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/security/ParamObfuscator.java
@@ -42,7 +42,7 @@ public class ParamObfuscator {
             // Return the payload, encoded as a Base64 string.
             return Base64.getUrlEncoder().encodeToString(ciphertext);
         } catch (IOException | NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException
-                | IllegalBlockSizeException e) {
+                | IllegalBlockSizeException | IllegalArgumentException e) {
             throw new ObfuscationException("An error occurred during obfuscation", e);
         }
     }
@@ -71,7 +71,7 @@ public class ParamObfuscator {
             // Return plaintext as String
             return new String(original);
         } catch (IOException | NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException
-                | IllegalBlockSizeException e) {
+                | IllegalBlockSizeException | IllegalArgumentException e) {
             throw new ObfuscationException("Something went wrong with the deobfuscation", e);
         }
 


### PR DESCRIPTION
Fixed bug introduced in https://github.com/dvsa/mot-public-api/pull/74 where an invalid vehicleID could produce a 500 (Input byte array has wrong 4-byte ending unit or Illegal base64 characters).

Instead, these exceptions will be re-thrown as 404s.