### PR TITLE
BL-7797: Add annual tests

### DIFF
--- a/api/src/main/java/uk/gov/dvsa/mot/app/ConfigKeys.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/app/ConfigKeys.java
@@ -13,6 +13,7 @@ public final class ConfigKeys {
     public static final String LogLevel = "LOG_LEVEL";
 
     public static final String HgvPsvApiUrl = "HGV_PSV_URL";
+    public static final String HgvPsvApiKey = "HGV_PSV_KEY";
     public static final String HgvPsvApiKeyEncrypted = "HGV_PSV_KEY_ENCRYPTED";
     public static final String HgvPsvApiConnectionTimeout = "HGV_PSV_CONNECTION_TIMEOUT";
 

--- a/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
@@ -146,7 +146,7 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
                 }
 
                 Integer decodedVehicleId = Integer.parseInt(deobfuscatedVehicleId);
-                logger.info("Decoded vehicle_id to {}", decodedVehicleId);
+                logger.trace("Decoded vehicle_id to {}", decodedVehicleId);
                 vehicles = tradeReadService.getVehiclesByVehicleId(decodedVehicleId);
 
                 if (CollectionUtils.isNullOrEmpty(vehicles)) {

--- a/api/src/main/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTest.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTest.java
@@ -7,6 +7,7 @@ import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
@@ -123,9 +124,8 @@ public class HgvPsvVehicleWithLatestTest implements VehicleWithLatestTest {
     }
 
     private static TestHistory findLatestTest(Vehicle vehicle) {
-        if (vehicle.getTestHistory() != null && vehicle.getTestHistory().length > 0) {
-            TestHistory[] testHistory = vehicle.getTestHistory();
-            return testHistory[testHistory.length - 1];
+        if (vehicle.getTestHistory() != null && !vehicle.getTestHistory().isEmpty()) {
+            return vehicle.getTestHistory().get(vehicle.getTestHistory().size() - 1);
         } else {
             return null;
         }

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/TradeServiceRequest.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/TradeServiceRequest.java
@@ -9,6 +9,7 @@ public class TradeServiceRequest {
     private Header[] header;
     private MotTestQueryParams queryParams = new MotTestQueryParams();
     private MotTestPathParams pathParams = new MotTestPathParams();
+    private AnnualTestQueryParams annualTestQueryParams = new AnnualTestQueryParams();
 
     private String requestId;
 
@@ -20,6 +21,7 @@ public class TradeServiceRequest {
                 ", header=" + Arrays.toString(header) +
                 ", queryParams=" + queryParams +
                 ", pathParams=" + pathParams +
+                ", annualTestQueryParams=" + annualTestQueryParams +
                 '}';
     }
 
@@ -71,6 +73,16 @@ public class TradeServiceRequest {
     public void setHeader(Header[] header) {
 
         this.header = header;
+    }
+
+    public AnnualTestQueryParams getAnnualTestQueryParams() {
+
+        return annualTestQueryParams;
+    }
+
+    public void setAnnualTestQueryParams(AnnualTestQueryParams annualTestQueryParams) {
+
+        this.annualTestQueryParams = annualTestQueryParams;
     }
 
     public MotTestQueryParams getQueryParams() {
@@ -138,6 +150,16 @@ public class TradeServiceRequest {
     public void setRegistration(String registration) {
 
         queryParams.registration = registration;
+    }
+
+    public String getRegistrations() {
+
+        return annualTestQueryParams.registrations;
+    }
+
+    public void setRegistrations(String registrations) {
+
+        annualTestQueryParams.registrations = registrations;
     }
 
     public String getMake() {
@@ -378,6 +400,27 @@ public class TradeServiceRequest {
                     ", number=" + number +
                     ", registration='" + registration + '\'' +
                     ", make='" + make + '\'' +
+                    '}';
+        }
+    }
+
+    public class AnnualTestQueryParams {
+
+        private String registrations;
+
+        public String getRegistrations() {
+            return registrations;
+        }
+
+        public void setRegistrations(String registrations) {
+            this.registrations = registrations;
+        }
+
+        @Override
+        public String toString() {
+
+            return "AnnualTestQueryParams{" +
+                    "registrations='" + registrations + '\'' +
                     '}';
         }
     }

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/AnnualTestResponse.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/AnnualTestResponse.java
@@ -1,0 +1,82 @@
+package uk.gov.dvsa.mot.trade.api.response.cvsvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class AnnualTestResponse {
+
+    private String testDate;
+    private String testType;
+    private String testResult;
+    private String testCertificateNumber;
+    private String expiryDate;
+    private String numberOfDefectsAtTest;
+    private String numberOfAdvisoryDefectsAtTest;
+    private List<DefectResponse> defects;
+
+    public String getTestDate() {
+        return testDate;
+    }
+
+    public void setTestDate(String testDate) {
+        this.testDate = testDate;
+    }
+
+    public String getTestType() {
+        return testType;
+    }
+
+    public void setTestType(String testType) {
+        this.testType = testType;
+    }
+
+    public String getTestResult() {
+        return testResult;
+    }
+
+    public void setTestResult(String testResult) {
+        this.testResult = testResult;
+    }
+
+    public String getTestCertificateNumber() {
+        return testCertificateNumber;
+    }
+
+    public void setTestCertificateNumber(String testCertificateNumber) {
+        this.testCertificateNumber = testCertificateNumber;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public String getNumberOfDefectsAtTest() {
+        return numberOfDefectsAtTest;
+    }
+
+    public void setNumberOfDefectsAtTest(String numberOfDefectsAtTest) {
+        this.numberOfDefectsAtTest = numberOfDefectsAtTest;
+    }
+
+    public String getNumberOfAdvisoryDefectsAtTest() {
+        return numberOfAdvisoryDefectsAtTest;
+    }
+
+    public void setNumberOfAdvisoryDefectsAtTest(String numberOfAdvisoryDefectsAtTest) {
+        this.numberOfAdvisoryDefectsAtTest = numberOfAdvisoryDefectsAtTest;
+    }
+
+    public List<DefectResponse> getDefects() {
+        return defects;
+    }
+
+    public void setDefects(List<DefectResponse> defects) {
+        this.defects = defects;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/AnnualTestV1Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/AnnualTestV1Response.java
@@ -1,0 +1,8 @@
+package uk.gov.dvsa.mot.trade.api.response.cvsvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnnualTestV1Response extends AnnualTestResponse {
+    // No changes for version 1
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/CvsVehicleResponse.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/CvsVehicleResponse.java
@@ -1,0 +1,91 @@
+package uk.gov.dvsa.mot.trade.api.response.cvsvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class CvsVehicleResponse {
+
+    private String registration;
+    private String make;
+    private String model;
+    private String manufactureDate;
+    private String vehicleType;
+    private String vehicleClass;
+    private String registrationDate;
+    private String annualTestExpiryDate;
+    private List<AnnualTestResponse> annualTests;
+
+    public String getRegistration() {
+        return registration;
+    }
+
+    public void setRegistration(String registration) {
+        this.registration = registration;
+    }
+
+    public String getMake() {
+        return make;
+    }
+
+    public void setMake(String make) {
+        this.make = make;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getManufactureDate() {
+        return manufactureDate;
+    }
+
+    public void setManufactureDate(String manufactureDate) {
+        this.manufactureDate = manufactureDate;
+    }
+
+    public String getVehicleType() {
+        return vehicleType;
+    }
+
+    public void setVehicleType(String vehicleType) {
+        this.vehicleType = vehicleType;
+    }
+
+    public String getVehicleClass() {
+        return vehicleClass;
+    }
+
+    public void setVehicleClass(String vehicleClass) {
+        this.vehicleClass = vehicleClass;
+    }
+
+    public String getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(String registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    public List<AnnualTestResponse> getAnnualTests() {
+        return annualTests;
+    }
+
+    public void setAnnualTests(List<AnnualTestResponse> annualTests) {
+        this.annualTests = annualTests;
+    }
+
+    public String getAnnualTestExpiryDate() {
+        return annualTestExpiryDate;
+    }
+
+    public void setAnnualTestExpiryDate(String annualTestExpiryDate) {
+        this.annualTestExpiryDate = annualTestExpiryDate;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/CvsVehicleV1Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/CvsVehicleV1Response.java
@@ -1,0 +1,8 @@
+package uk.gov.dvsa.mot.trade.api.response.cvsvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CvsVehicleV1Response extends CvsVehicleResponse {
+    // No changes for version 1
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/DefectResponse.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/DefectResponse.java
@@ -1,0 +1,48 @@
+package uk.gov.dvsa.mot.trade.api.response.cvsvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class DefectResponse {
+
+    private String failureItemNo;
+    private String failureReason;
+    private String severityCode;
+    private String severityDescription;
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public String getFailureItemNo() {
+        return failureItemNo;
+    }
+
+    public void setFailureItemNo(Integer failureItemNo) {
+        if (failureItemNo != null) {
+            this.failureItemNo = failureItemNo.toString();
+            return;
+        }
+        this.failureItemNo = null;
+    }
+
+    public String getSeverityCode() {
+        return severityCode;
+    }
+
+    public void setSeverityCode(String severityCode) {
+        this.severityCode = severityCode;
+    }
+
+    public String getSeverityDescription() {
+        return severityDescription;
+    }
+
+    public void setSeverityDescription(String severityDescription) {
+        this.severityDescription = severityDescription;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/DefectV1Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/cvsvehicle/DefectV1Response.java
@@ -1,0 +1,8 @@
+package uk.gov.dvsa.mot.trade.api.response.cvsvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DefectV1Response extends DefectResponse {
+    // No changes for version 1
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsTestTypeMapFilter.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsTestTypeMapFilter.java
@@ -1,0 +1,50 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle;
+
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CvsTestTypeMapFilter {
+
+    private static final List<String> visibleTestTypes = new ArrayList<>(
+            Arrays.asList(
+                    "1ST PAID RETEST",
+                    "1ST PG9 FULL INSPECTION & FEE",
+                    "1ST PG9 FULL INSPECTION & FEE",
+                    "1ST PG9 PAID RETEST",
+                    "1ST TEST MV",
+                    "1ST TEST TRAILER",
+                    "1ST TEST TRI AXLE FREE RETEST",
+                    "6A PG9 + S/BELT PAID RETEST",
+                    "6A PG9 FULL INSP & FEE + SBELT",
+                    "ANNUAL MV",
+                    "ANNUAL PSV LARGE",
+                    "ANNUAL PSV SMALL",
+                    "ANNUAL TEST HAULAGE VEHICLE",
+                    "ANNUAL TRAILER",
+                    "ARTIC BUS ANNUAL TEST LARGE",
+                    "ARTIC BUS FULLY PAID RETEST",
+                    "ARTIC BUS PART PAID RETEST",
+                    "CLASS 6A ANNUAL",
+                    "CLASS 6A FIRST TEST",
+                    "CLASS 6A PAID RETEST",
+                    "COIF + S/BELT + TEST CERT",
+                    "COIF + TEST CERTIFICATE",
+                    "COIF PAID RETEST + TEST CERT",
+                    "COIF+S/BELT PAID RETEST + CERT",
+                    "FIRST TEST HAULAGE VEHICLE",
+                    "PAID RETEST",
+                    "PAID RETEST HAULAGE VEHICLE",
+                    "PART PAID RETEST",
+                    "PG9 FULL INSPECTION & FEE",
+                    "PG9 PAID RETEST",
+                    "PG9 PART PAID RETEST",
+                    "TRI AXLE FREE RETEST"
+            ));
+
+    public static boolean canDisplayTest(TestHistory testHistory) {
+        return visibleTestTypes.contains(testHistory.getTestType());
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleResponseMapper.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleResponseMapper.java
@@ -1,0 +1,48 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle;
+
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.CvsVehicleResponse;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public abstract class CvsVehicleResponseMapper {
+
+    private static final DateTimeFormatter HGV_PSV_API_DATE_PATTERN = DateTimeFormatter.ofPattern("d/M/yyyy");
+
+    public abstract List<CvsVehicleResponse> map(List<Vehicle> vehicles);
+
+    protected void fillBaseVehicleResponseProperties(CvsVehicleResponse cvsVehicleResponse, Vehicle vehicle) {
+        cvsVehicleResponse.setRegistration(vehicle.getVehicleIdentifier());
+        cvsVehicleResponse.setMake(vehicle.getMake());
+        cvsVehicleResponse.setModel(vehicle.getModel());
+        cvsVehicleResponse.setManufactureDate(transformDate(vehicle.getManufactureDate()));
+        cvsVehicleResponse.setVehicleType(vehicle.getVehicleType());
+        cvsVehicleResponse.setVehicleClass(vehicle.getVehicleClass());
+        cvsVehicleResponse.setRegistrationDate(transformDate(vehicle.getRegistrationDate()));
+    }
+
+    protected void fillBaseTestResponseProperties(AnnualTestResponse annualTestResponse, TestHistory testHistory) {
+        annualTestResponse.setTestDate(transformDate(testHistory.getTestDate()));
+        annualTestResponse.setTestType(testHistory.getTestType());
+        annualTestResponse.setTestResult(testHistory.getTestResult());
+        annualTestResponse.setTestCertificateNumber(testHistory.getTestCertificateSerialNo());
+        annualTestResponse.setExpiryDate(transformDate(testHistory.getTestCertificateExpiryDateAtTest()));
+        annualTestResponse.setNumberOfDefectsAtTest(testHistory.getNumberOfDefectsAtTest().toString());
+        annualTestResponse.setNumberOfAdvisoryDefectsAtTest(testHistory.getNumberOfAdvisoryDefectsAtTest().toString());
+    }
+
+    protected String transformDate(String hgvPsvApiDate) {
+
+        if (hgvPsvApiDate == null) {
+            return null;
+        }
+
+        LocalDate date = LocalDate.parse(hgvPsvApiDate, HGV_PSV_API_DATE_PATTERN);
+
+        return date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleResponseMapperFactory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleResponseMapperFactory.java
@@ -1,0 +1,33 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CvsVehicleResponseMapperFactory {
+    private static final Logger logger = LogManager.getLogger(CvsVehicleResponseMapperFactory.class);
+
+    public CvsVehicleResponseMapper getMapper(String version) {
+
+        logger.trace("Entering CvsVehicleResponseMapperFactory.getMapper");
+        CvsVehicleResponseMapper mapper;
+
+        if (version == null) {
+            logger.debug("API version requested is null, using v6");
+            mapper = new CvsVehicleV6ResponseMapper();
+        } else {
+            switch (version) {
+                case "v6":
+                    mapper = new CvsVehicleV6ResponseMapper();
+                    break;
+                default:
+                    logger.warn("Unknown API version selected. Using v6");
+                    mapper = new CvsVehicleV6ResponseMapper();
+            }
+        }
+
+        logger.debug("Mapper version selected: " + mapper.getClass().getSimpleName());
+        logger.trace("Exiting CvsVehicleResponseMapperFactory.getMapper");
+        return mapper;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleV6ResponseMapper.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleV6ResponseMapper.java
@@ -1,0 +1,69 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle;
+
+import uk.gov.dvsa.mot.app.util.CollectionUtils;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.AnnualTestV1Response;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.CvsVehicleResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.CvsVehicleV1Response;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.DefectResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.DefectV1Response;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+
+public class CvsVehicleV6ResponseMapper extends CvsVehicleResponseMapper {
+
+    public List<CvsVehicleResponse> map(List<Vehicle> vehicles) {
+        return vehicles.stream().map(this::mapVehicle).collect(Collectors.toList());
+    }
+
+    private CvsVehicleResponse mapVehicle(Vehicle vehicle) {
+        CvsVehicleV1Response vehicleResponse = new CvsVehicleV1Response();
+        this.fillBaseVehicleResponseProperties(vehicleResponse, vehicle);
+        vehicleResponse.setAnnualTestExpiryDate(transformDate(vehicle.getTestCertificateExpiryDate()));
+
+        if (!CollectionUtils.isNullOrEmpty(vehicle.getTestHistory())) {
+            vehicleResponse.setAnnualTests(
+                    vehicle.getTestHistory()
+                            .stream()
+                            .map(this::mapTest)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList())
+            );
+        }
+
+        return vehicleResponse;
+    }
+
+    private AnnualTestResponse mapTest(TestHistory testHistory) {
+        if (!CvsTestTypeMapFilter.canDisplayTest(testHistory)) {
+            return null;
+        }
+
+        AnnualTestV1Response annualTestResponse = new AnnualTestV1Response();
+        this.fillBaseTestResponseProperties(annualTestResponse, testHistory);
+
+        if (!CollectionUtils.isNullOrEmpty(testHistory.getTestHistoryDefects())) {
+            annualTestResponse.setDefects(
+                    testHistory.getTestHistoryDefects().stream().map(this::mapDefect).collect(Collectors.toList())
+            );
+        }
+
+        return annualTestResponse;
+    }
+
+    private DefectResponse mapDefect(Defect defectItem) {
+        DefectV1Response defectResponse = new DefectV1Response();
+        defectResponse.setFailureItemNo(defectItem.getFailureItemNo());
+        defectResponse.setSeverityCode(defectItem.getSeverityCode());
+        defectResponse.setSeverityDescription(defectItem.getSeverityDescription());
+        defectResponse.setFailureReason(defectItem.getFailureReason());
+
+        return defectResponse;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeAnnualTestsReadService.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeAnnualTestsReadService.java
@@ -1,0 +1,48 @@
+package uk.gov.dvsa.mot.trade.read.core;
+
+import com.google.inject.Inject;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import uk.gov.dvsa.mot.vehicle.hgv.HgvVehicleProvider;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TradeAnnualTestsReadService {
+
+    private static final Logger logger = LogManager.getLogger(TradeAnnualTestsReadService.class);
+
+    private HgvVehicleProvider hgvVehicleProvider;
+
+    @Inject
+    public void setHgvVehicleProvider(HgvVehicleProvider hgvVehicleProvider) {
+
+        this.hgvVehicleProvider = hgvVehicleProvider;
+    }
+
+    public List<Vehicle> getAnnualTests(Collection<String> requestedRegistrations) throws Exception {
+
+        List<Vehicle> vehicleList = new ArrayList<>();
+
+        for (String registration: requestedRegistrations) {
+            if (registration.isEmpty()) {
+                logger.trace("Empty registration, skipping...");
+                continue;
+            }
+            logger.debug("Querying search api for registration {}", registration);
+            uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle = hgvVehicleProvider.getVehicle(registration);
+
+            if (vehicle != null) {
+                logger.trace("Vehicle with registration {} found. Appending to result...", registration);
+                vehicleList.add(vehicle);
+            }
+        }
+
+        return vehicleList;
+    }
+
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/HgvConfiguration.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/HgvConfiguration.java
@@ -18,7 +18,10 @@ public class HgvConfiguration {
 
     public HgvConfiguration() throws IOException {
 
-        // if api key is not already set
+        if (StringUtils.isNullOrEmpty(apiKey)) {
+            apiKey = ConfigManager.getEnvironmentVariable(ConfigKeys.HgvPsvApiKey);
+        }
+
         if (StringUtils.isNullOrEmpty(apiKey)) {
             apiKey = ConfigManager.getEnvironmentVariable(ConfigKeys.HgvPsvApiKeyEncrypted);
         }

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/HgvVehicleProvider.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/HgvVehicleProvider.java
@@ -16,6 +16,7 @@ import uk.gov.dvsa.mot.vehicle.hgv.response.ResponseTestHistory;
 import uk.gov.dvsa.mot.vehicle.hgv.response.ResponseVehicle;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.client.Client;
@@ -34,12 +35,12 @@ public class HgvVehicleProvider {
     public Vehicle getVehicle(String registration) throws Exception {
 
         Vehicle vehicle;
-        TestHistory[] vehicleTestHistory;
+        List<TestHistory> vehicleTestHistory;
 
         try {
             CompletableFuture<Vehicle> vehicleFuture = CompletableFutureWrapper.supplyAsync(() -> getHgvVehicle(registration));
 
-            CompletableFuture<TestHistory[]> vehicleTestHistoryFuture = CompletableFutureWrapper.supplyAsync(
+            CompletableFuture<List<TestHistory>> vehicleTestHistoryFuture = CompletableFutureWrapper.supplyAsync(
                     () -> getHgvVehicleTestHistory(registration));
 
             vehicle = vehicleFuture.get();
@@ -61,7 +62,7 @@ public class HgvVehicleProvider {
         return response != null ? response.getVehicle() : null;
     }
 
-    private TestHistory[] getHgvVehicleTestHistory(String registration) {
+    private List<TestHistory> getHgvVehicleTestHistory(String registration) {
         ResponseTestHistory response = getHgvResponse(registration, "/testhistory/moth", ResponseTestHistory.class);
 
         return response != null ? response.getTestHistory() : null;

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Defect.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Defect.java
@@ -1,0 +1,62 @@
+package uk.gov.dvsa.mot.vehicle.hgv.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Defect {
+
+    private Integer failureItemNo;
+    private String severityCode;
+    private String severityDescription;
+    private String failureReason;
+    private String defectCode;
+    private String defectDescription;
+
+    public Integer getFailureItemNo() {
+        return failureItemNo;
+    }
+
+    public void setFailureItemNo(Integer failureItemNo) {
+        this.failureItemNo = failureItemNo;
+    }
+
+    public String getSeverityCode() {
+        return severityCode;
+    }
+
+    public void setSeverityCode(String severityCode) {
+        this.severityCode = severityCode;
+    }
+
+    public String getSeverityDescription() {
+        return severityDescription;
+    }
+
+    public void setSeverityDescription(String severityDescription) {
+        this.severityDescription = severityDescription;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public String getDefectCode() {
+        return defectCode;
+    }
+
+    public void setDefectCode(String defectCode) {
+        this.defectCode = defectCode;
+    }
+
+    public String getDefectDescription() {
+        return defectDescription;
+    }
+
+    public void setDefectDescription(String defectDescription) {
+        this.defectDescription = defectDescription;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/TestHistory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/TestHistory.java
@@ -2,6 +2,10 @@ package uk.gov.dvsa.mot.vehicle.hgv.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.annotation.JSONP;
+
+import java.util.List;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestHistory {
     private String testType;
@@ -13,6 +17,7 @@ public class TestHistory {
     private Integer numberOfAdvisoryDefectsAtTest;
     private String vehicleIdentifierAtTest;
     private String testCertificateSerialNo;
+    private List<Defect> testHistoryDefects;
 
     public String getTestType() {
         return testType;
@@ -84,5 +89,13 @@ public class TestHistory {
 
     public void setVehicleIdentifierAtTest(String vehicleIdentifierAtTest) {
         this.vehicleIdentifierAtTest = vehicleIdentifierAtTest;
+    }
+
+    public List<Defect> getTestHistoryDefects() {
+        return testHistoryDefects;
+    }
+
+    public void setTestHistoryDefects(List<Defect> defects) {
+        this.testHistoryDefects = defects;
     }
 }

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Vehicle.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Vehicle.java
@@ -2,9 +2,11 @@ package uk.gov.dvsa.mot.vehicle.hgv.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.util.List;
+
 public class Vehicle {
     @JsonIgnore
-    private TestHistory[] testHistory;
+    private List<TestHistory> testHistory;
     private String vehicleClass;
     private String vehicleType;
     private String chassisType;
@@ -19,11 +21,11 @@ public class Vehicle {
     private String make;
     private String model;
 
-    public void setTestHistory(TestHistory[] testHistory) {
+    public void setTestHistory(List<TestHistory> testHistory) {
         this.testHistory = testHistory;
     }
 
-    public TestHistory[] getTestHistory() {
+    public List<TestHistory> getTestHistory() {
         return testHistory;
     }
 

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/response/ResponseTestHistory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/response/ResponseTestHistory.java
@@ -3,14 +3,17 @@ package uk.gov.dvsa.mot.vehicle.hgv.response;
 
 import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
 
-public class ResponseTestHistory {
-    TestHistory[] testHistory;
+import java.util.List;
 
-    public TestHistory[] getTestHistory() {
+public class ResponseTestHistory {
+
+    List<TestHistory> testHistory;
+
+    public List<TestHistory> getTestHistory() {
         return testHistory;
     }
 
-    public void setTestHistory(TestHistory[] testHistory) {
+    public void setTestHistory(List<TestHistory> testHistory) {
         this.testHistory = testHistory;
     }
 }

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandlerTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandlerTest.java
@@ -19,6 +19,9 @@ import uk.gov.dvsa.mot.trade.api.Vehicle;
 import uk.gov.dvsa.mot.trade.api.response.VehicleResponse;
 import uk.gov.dvsa.mot.trade.api.response.mapper.VehicleResponseMapperFactory;
 import uk.gov.dvsa.mot.trade.api.response.mapper.VehicleV4ResponseMapper;
+import uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle.CvsVehicleResponseMapperFactory;
+import uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle.CvsVehicleV6ResponseMapper;
+import uk.gov.dvsa.mot.trade.read.core.TradeAnnualTestsReadService;
 import uk.gov.dvsa.mot.trade.read.core.TradeReadService;
 
 import java.util.ArrayList;
@@ -42,10 +45,19 @@ public class TradeServiceRequestHandlerTest {
     private TradeReadService tradeReadService;
 
     @Mock
+    private TradeAnnualTestsReadService tradeAnnualTestsReadService;
+
+    @Mock
     private VehicleResponseMapperFactory vehicleResponseMapperFactory;
 
     @Mock
+    private CvsVehicleResponseMapperFactory cvsVehicleResponseMapperFactory;
+
+    @Mock
     private VehicleV4ResponseMapper vehicleMapper;
+
+    @Mock
+    private CvsVehicleV6ResponseMapper cvsVehicleMapper;
 
     @Mock
     private Context lambdaContext;
@@ -71,7 +83,7 @@ public class TradeServiceRequestHandlerTest {
             throws TradeException, ParamObfuscator.ObfuscationException {
 
         TradeServiceRequestHandler sut = new TradeServiceRequestHandler(false);
-        sut.setTradeReadService(tradeReadService);
+        sut.setTradeReadService(tradeReadService, tradeAnnualTestsReadService);
         sut.setVehicleResponseMapperFactory(vehicleResponseMapperFactory);
 
         String obfuscatedVehicleId = null;
@@ -85,6 +97,23 @@ public class TradeServiceRequestHandlerTest {
     }
 
     /**
+     * Convenience function for testing getTradeAnnualTests calls with less boilerplate.
+     *
+     * @param request The request to test against
+     * @return The result of the call to getTradeAnnualTests
+     * @throws TradeException if getTradeAnnualTests throws
+     */
+    private Response createHandlerAndGetTradeAnnualTests(TradeServiceRequest request)
+            throws TradeException {
+
+        TradeServiceRequestHandler sut = new TradeServiceRequestHandler(false);
+        sut.setTradeReadService(tradeReadService, tradeAnnualTestsReadService);
+        sut.setHgvResponseMapperFactory(cvsVehicleResponseMapperFactory);
+
+        return sut.getTradeAnnualTests(request.getRegistrations(), requestContext);
+    }
+
+    /**
      * Convenience function for testing getTradeMotTestsLegacy calls with less boilerplate
      *
      * @param registration is a path parameter passed to getTradeMotTestsLegacy
@@ -95,7 +124,7 @@ public class TradeServiceRequestHandlerTest {
     private Response createHandlerAndGetLegacy(String registration, String make) throws TradeException {
 
         TradeServiceRequestHandler sut = new TradeServiceRequestHandler(false);
-        sut.setTradeReadService(tradeReadService);
+        sut.setTradeReadService(tradeReadService, tradeAnnualTestsReadService);
         sut.setVehicleResponseMapperFactory(vehicleResponseMapperFactory);
 
         return sut.getTradeMotTestsLegacy(registration, make, requestContext);
@@ -104,6 +133,7 @@ public class TradeServiceRequestHandlerTest {
     @Before
     public void setup() {
         when(vehicleResponseMapperFactory.getMapper(any())).thenReturn(vehicleMapper);
+        when(cvsVehicleResponseMapperFactory.getMapper(any())).thenReturn(cvsVehicleMapper);
         request = new TradeServiceRequest();
     }
 
@@ -120,7 +150,7 @@ public class TradeServiceRequestHandlerTest {
         when(tradeReadService.getMakes()).thenReturn(theMakes);
 
         TradeServiceRequestHandler sut = new TradeServiceRequestHandler(false);
-        sut.setTradeReadService(tradeReadService);
+        sut.setTradeReadService(tradeReadService, tradeAnnualTestsReadService);
 
         List<String> makes = sut.getMakes(null, lambdaContext);
 
@@ -136,7 +166,7 @@ public class TradeServiceRequestHandlerTest {
         when(tradeReadService.getMakes()).thenThrow(new IndexOutOfBoundsException());
 
         TradeServiceRequestHandler sut = new TradeServiceRequestHandler(false);
-        sut.setTradeReadService(tradeReadService);
+        sut.setTradeReadService(tradeReadService, tradeAnnualTestsReadService);
 
         sut.getMakes(null, lambdaContext);
     }
@@ -551,6 +581,58 @@ public class TradeServiceRequestHandlerTest {
 
         createHandlerAndGetTradeMotTests(request);
     }
+
+    @Test(expected = BadRequestException.class)
+    public void getTradeAnnualTests_Registrations_UndefinedThrowsBadRequestException() throws TradeException {
+
+        createHandlerAndGetTradeAnnualTests(request);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getTradeAnnualTests_Registrations_EmptyThrowsBadRequestException() throws TradeException {
+
+        final String registrations = "";
+
+        request.setRegistrations(registrations);
+
+        createHandlerAndGetTradeAnnualTests(request);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getTradeAnnualTests_Registrations_MoreThan50DefinedThrowsBadRequestException() throws TradeException {
+
+        final String registrations = "" +
+                "REG001, REG002, REG003, REG004, REG005, REG006, REG007, REG008, REG009, REG010, " +
+                "REG011, REG012, REG013, REG014, REG015, REG016, REG017, REG018, REG019, REG020, " +
+                "REG021, REG022, REG023, REG024, REG025, REG026, REG027, REG028, REG029, REG030, " +
+                "REG031, REG032, REG033, REG034, REG035, REG036, REG037, REG038, REG039, REG040, " +
+                "REG041, REG042, REG043, REG044, REG045, REG046, REG047, REG048, REG049, REG050, " +
+                "REG051";
+
+        request.setRegistrations(registrations);
+
+        createHandlerAndGetTradeAnnualTests(request);
+    }
+
+    @Test()
+    public void getTradeAnnualTests_Registrations_DefiningOneRegistrationReturnsOneVehicle() throws TradeException, Exception {
+
+        final String registrations = "REG001, REG002";
+
+        request.setRegistrations(registrations);
+
+        uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle = new uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle();
+        vehicle.setVehicleIdentifier("REG001");
+
+        uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle1 = new uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle();
+        vehicle.setVehicleIdentifier("REG002");
+
+        when(tradeAnnualTestsReadService.getAnnualTests(any())).thenReturn(Arrays.asList(vehicle, vehicle1));
+
+        createHandlerAndGetTradeAnnualTests(request);
+    }
+
+
 
     /**
      * A null request should get us an InvalidResourceException

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTestTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTestTest.java
@@ -7,6 +7,8 @@ import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -68,11 +70,11 @@ public class HgvPsvVehicleWithLatestTestTest {
     }
 
     private Vehicle createVehicleWithTestHistory(String vehicleType) {
-        TestHistory[] testHistory = new TestHistory[1];
+        List<TestHistory> testHistory = new ArrayList<>();
         TestHistory historyItem =  new TestHistory();
         historyItem.setTestCertificateSerialNo(TEST_NUMBER);
         historyItem.setTestDate("03/01/2013");
-        testHistory[0] = historyItem;
+        testHistory.add(historyItem);
 
         Vehicle vehicle = createVehicle(vehicleType);
         vehicle.setTestHistory(testHistory);

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProviderTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProviderTest.java
@@ -16,9 +16,11 @@ import uk.gov.dvsa.mot.vehicle.hgv.HgvVehicleProvider;
 import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
 import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Optional;
 
 import static com.googlecode.catchexception.CatchException.catchException;
@@ -137,7 +139,10 @@ public class MotrVehicleHistoryProviderTest {
         hgvPsvVehicle.setTestCertificateExpiryDate("01/03/2018");
         TestHistory historyItem = new TestHistory();
         historyItem.setTestDate("02/02/2017");
-        hgvPsvVehicle.setTestHistory(new TestHistory[] { historyItem });
+
+        List<TestHistory> testHistory = new ArrayList<>();
+        testHistory.add(historyItem);
+        hgvPsvVehicle.setTestHistory(testHistory);
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(motVehicle);
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(Optional.empty());

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/MockVehicleDataHelper.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/MockVehicleDataHelper.java
@@ -3,8 +3,12 @@ package uk.gov.dvsa.mot.trade.api.response.mapper;
 import uk.gov.dvsa.mot.trade.api.MotTest;
 import uk.gov.dvsa.mot.trade.api.RfrAndAdvisoryItem;
 import uk.gov.dvsa.mot.trade.api.Vehicle;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class MockVehicleDataHelper {
     public static final String DEFICIENCY_CATEGORY_TYPE_PRE_EU = "PE";
@@ -78,5 +82,119 @@ public class MockVehicleDataHelper {
         rfr.setDeficiencyCategoryDescription("Major");
 
         return rfr;
+    }
+
+    public static uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle getCvsVehicleContainingSpecificTestType(
+            String vehicleType, List<String> testTypes) {
+
+        uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle = getCvsVehicle(vehicleType, true);
+
+        vehicle.getTestHistory().clear();
+
+        for (String testType: testTypes) {
+            vehicle.getTestHistory().add(getCvsTest(2000, true, vehicle, testType));
+        }
+
+        return vehicle;
+    }
+
+    public static uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle getCvsVehicle(String vehicleType, boolean hasTests) {
+
+        uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle = new uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle();
+
+        vehicle.setVehicleIdentifier(vehicleType + "REG123");
+        vehicle.setMake("Some" + vehicleType + "Make");
+        vehicle.setModel("Some" + vehicleType + "Model");
+        vehicle.setManufactureDate("30/12/2003");
+        vehicle.setVehicleType(vehicleType);
+        vehicle.setVehicleClass("V");
+        vehicle.setRegistrationDate("30/06/2003");
+        vehicle.setTestCertificateExpiryDate("09/03/2019");
+
+        if (hasTests) {
+            List<TestHistory> testHistory = new ArrayList<>();
+            testHistory.add(getCvsTest(2010, true, vehicle));
+            testHistory.add(getCvsTest(2009, false, vehicle));
+            vehicle.setTestHistory(testHistory);
+        }
+
+        return vehicle;
+    }
+
+    public static TestHistory getCvsTest(int year, boolean passed, uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle, String testType) {
+        TestHistory testHistory = getCvsTest(year, passed, vehicle);
+        testHistory.setTestType(testType);
+
+        return testHistory;
+    }
+
+    public static TestHistory getCvsTest(int year, boolean passed, uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle) {
+
+        TestHistory testHistory = new TestHistory();
+
+        switch (vehicle.getVehicleType()) {
+            case "HGV":
+                testHistory.setTestType("ANNUAL MV");
+                break;
+            case "PSV":
+                testHistory.setTestType("ANNUAL PSV LARGE");
+                break;
+            case "Trailer":
+                testHistory.setTestType("ANNUAL TRAILER");
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid vehicle type set: valid types are 'HGV', 'PSV' and 'Trailer'");
+        }
+
+        testHistory.setLocation("CHECK SITE 44272, STREET_NAME 44272, TOWN 44272, COUNTRY 44272, XY99 0ZZ");
+        testHistory.setTestResult(((passed) ? "Pass" : "Fail"));
+        testHistory.setTestDate("01/01/2019");
+        testHistory.setTestCertificateExpiryDateAtTest("01/01/2020");
+        testHistory.setTestCertificateSerialNo("GG000001");
+        testHistory.setVehicleIdentifierAtTest(vehicle.getVehicleIdentifier());
+
+        if (passed) {
+            testHistory.setNumberOfAdvisoryDefectsAtTest(0);
+            testHistory.setNumberOfDefectsAtTest(0);
+        } else {
+            testHistory.setNumberOfAdvisoryDefectsAtTest(0);
+            testHistory.setNumberOfDefectsAtTest(2);
+
+            List<Defect> defectList = new ArrayList<>();
+            defectList.add(getCvsDefect(38, "F"));
+            defectList.add(getCvsDefect(63, "A"));
+            testHistory.setTestHistoryDefects(defectList);
+        }
+
+        return testHistory;
+    }
+
+    private static Defect getCvsDefect(int failureItemNo, String severityCode) {
+
+        Defect defect = new Defect();
+
+        defect.setFailureItemNo(failureItemNo);
+        if (failureItemNo == 38) {
+            defect.setFailureReason("Service Brake Operation");
+        } else if (failureItemNo == 63) {
+            defect.setFailureReason("Lamps");
+        }
+
+        defect.setSeverityCode(severityCode);
+        switch (severityCode) {
+            case "F":
+                defect.setSeverityDescription("Failure");
+                break;
+            case "A":
+                defect.setSeverityDescription("Advisory");
+                break;
+            case "R":
+                defect.setSeverityDescription("Pass after rectification");
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid severity code set: valid codes are 'F', 'A' and 'R'");
+        }
+
+        return defect;
     }
 }

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/VehicleV5ResponseMapperTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/VehicleV5ResponseMapperTest.java
@@ -11,7 +11,6 @@ import uk.gov.dvsa.mot.trade.api.response.RfrAndAdvisoryV2Response;
 import uk.gov.dvsa.mot.trade.api.response.VehicleResponse;
 import uk.gov.dvsa.mot.trade.api.response.VehicleV4Response;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsTestTypeMapFilterTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsTestTypeMapFilterTest.java
@@ -1,0 +1,34 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle;
+
+import org.junit.Test;
+
+import uk.gov.dvsa.mot.trade.api.response.mapper.MockVehicleDataHelper;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class CvsTestTypeMapFilterTest {
+
+    @Test
+    public void vehicleTestsTypeNotWhitelistedAreOmitted() {
+
+        Vehicle vehicle = MockVehicleDataHelper.getCvsVehicle("HGV", false);
+
+        assertTrue(CvsTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getCvsTest(2000, true, vehicle, "ANNUAL MV")
+        ));
+
+        assertTrue(CvsTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getCvsTest(2000, true, vehicle, "PAID RETEST")
+        ));
+
+        assertFalse(CvsTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getCvsTest(2000, true, vehicle, "SOME OTHER TEST")
+        ));
+
+        assertFalse(CvsTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getCvsTest(2000, true, vehicle, "PAID")
+        ));
+    }
+}

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleV6ResponseMapperTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/cvsvehicle/CvsVehicleV6ResponseMapperTest.java
@@ -1,0 +1,271 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.cvsvehicle;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.AnnualTestV1Response;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.CvsVehicleResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.CvsVehicleV1Response;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.DefectResponse;
+import uk.gov.dvsa.mot.trade.api.response.cvsvehicle.DefectV1Response;
+import uk.gov.dvsa.mot.trade.api.response.mapper.MockVehicleDataHelper;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+public class CvsVehicleV6ResponseMapperTest {
+
+    private CvsVehicleV6ResponseMapper vehicleResponseMapper;
+
+    @Before
+    public void init() {
+        vehicleResponseMapper = new CvsVehicleV6ResponseMapper();
+    }
+
+    @Test
+    public void map_mapsAllPropertiesCorrectly() {
+        List<Vehicle> vehiclesFromDb = Arrays.asList(
+                MockVehicleDataHelper.getCvsVehicle("HGV", true),
+                MockVehicleDataHelper.getCvsVehicle("PSV", true),
+                MockVehicleDataHelper.getCvsVehicle("Trailer", false)
+        );
+
+        List<CvsVehicleResponse> mappedVehicles = vehicleResponseMapper.map(vehiclesFromDb);
+
+        assertVehiclesMapped(vehiclesFromDb, mappedVehicles);
+    }
+
+    @Test
+    public void ensureOnlyValidTestTypesAreMapped() {
+
+        List<Vehicle> vehicleList = Arrays.asList(
+                MockVehicleDataHelper.getCvsVehicleContainingSpecificTestType(
+                        "HGV", Arrays.asList("INVALIDTYPE", "ANNUAL MV")),
+                MockVehicleDataHelper.getCvsVehicleContainingSpecificTestType(
+                        "PSV", Arrays.asList("PAID RETEST", "1ST PAID RETEST", "NOPE", "ANNUAL PSV SMALL")),
+                MockVehicleDataHelper.getCvsVehicleContainingSpecificTestType(
+                        "Trailer", Arrays.asList("TRI AXLE FREE RETEST", "ANNUAL TRAILER"))
+        );
+
+        List<CvsVehicleResponse> mappedVehicles = vehicleResponseMapper.map(vehicleList);
+
+        assertEquals("Defined vehicle list size does not match response vehicle list size",
+                vehicleList.size(),
+                mappedVehicles.size()
+        );
+
+        // Assert we get the correct first vehicle of type HGV
+        CvsVehicleResponse vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("HGV"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of HGV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in HGV response test history",
+                1,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that HGV response vehicle contained ANNUAL MV",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL MV")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that HGV response vehicle did NOT contain INVALIDTYPE",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .noneMatch(t -> t.getTestType()
+                                .equals("INVALIDTYPE")
+                        )
+        );
+
+        // Assert we get the correct first vehicle of type PSV
+        vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("PSV"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of PSV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in PSV response test history",
+                3,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained PAID RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("PAID RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained 1ST PAID RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("1ST PAID RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained ANNUAL PSV SMALL",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL PSV SMALL")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle NOT contain INVALIDTYPE",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .noneMatch(t -> t.getTestType()
+                                .equals("NOPE")
+                        )
+        );
+
+        // Assert we get the correct first vehicle of type PSV
+        vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("Trailer"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of PSV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in PSV response test history",
+                2,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that Trailer response vehicle contained TRI AXLE FREE RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("TRI AXLE FREE RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that Trailer response vehicle contained ANNUAL TRAILER",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL TRAILER")
+                        )
+        );
+    }
+
+    private void assertVehiclesMapped(List<Vehicle> vehicles, List<CvsVehicleResponse> mappedVehicles) {
+        assertEquals(vehicles.size(), mappedVehicles.size());
+
+        for (int i = 0; i < vehicles.size(); i++) {
+            Vehicle vehicle = vehicles.get(i);
+            assertEquals(CvsVehicleV1Response.class, mappedVehicles.get(i).getClass());
+            CvsVehicleV1Response responseVehicle = (CvsVehicleV1Response) mappedVehicles.get(i);
+
+            assertEquals(vehicle.getVehicleIdentifier(), responseVehicle.getRegistration());
+            assertEquals(vehicle.getMake(), responseVehicle.getMake());
+            assertEquals(vehicle.getModel(), responseVehicle.getModel());
+            assertEquals(vehicle.getVehicleType(), responseVehicle.getVehicleType());
+            assertEquals(vehicle.getVehicleClass(), responseVehicle.getVehicleClass());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getRegistrationDate()),
+                    responseVehicle.getRegistrationDate()
+            );
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getManufactureDate()),
+                    responseVehicle.getManufactureDate()
+            );
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getTestCertificateExpiryDate()),
+                    responseVehicle.getAnnualTestExpiryDate()
+            );
+            assertAnnualTestMapped(vehicle.getTestHistory(), responseVehicle.getAnnualTests());
+        }
+    }
+
+    private void assertAnnualTestMapped(List<TestHistory> annualTests, List<AnnualTestResponse> mappedAnnualTests) {
+        if (annualTests == null) {
+            assertNull(mappedAnnualTests);
+            return;
+        }
+        assertEquals(annualTests.size(), mappedAnnualTests.size());
+
+        for (int i = 0; i < annualTests.size(); i++) {
+            TestHistory annualTest = annualTests.get(i);
+
+            assertEquals(AnnualTestV1Response.class, mappedAnnualTests.get(i).getClass());
+            AnnualTestV1Response responseTest = (AnnualTestV1Response) mappedAnnualTests.get(i);
+
+            assertEquals(annualTest.getTestType(), responseTest.getTestType());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(annualTest.getTestDate()),
+                    responseTest.getTestDate()
+            );
+            assertEquals(annualTest.getTestResult(), responseTest.getTestResult());
+            assertEquals(annualTest.getTestCertificateSerialNo(), responseTest.getTestCertificateNumber());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(annualTest.getTestCertificateExpiryDateAtTest()),
+                    responseTest.getExpiryDate()
+            );
+            assertEquals(annualTest.getNumberOfAdvisoryDefectsAtTest().toString(), responseTest.getNumberOfAdvisoryDefectsAtTest());
+            assertEquals(annualTest.getNumberOfDefectsAtTest().toString(), responseTest.getNumberOfDefectsAtTest());
+
+            assertDefectsMapped(annualTest.getTestHistoryDefects(), responseTest.getDefects());
+        }
+    }
+
+    private void assertDefectsMapped(List<Defect> defects, List<DefectResponse> mappedDefects) {
+        if (defects == null) {
+            assertNull(mappedDefects);
+            return;
+        }
+        assertEquals(defects.size(), mappedDefects.size());
+
+        for (int i = 0; i < defects.size(); i++) {
+            Defect defect = defects.get(i);
+
+            assertEquals(DefectV1Response.class, mappedDefects.get(i).getClass());
+            DefectV1Response responseDefect = (DefectV1Response) mappedDefects.get(i);
+
+            assertEquals(defect.getFailureItemNo().toString(), responseDefect.getFailureItemNo());
+            assertEquals(defect.getFailureReason(), responseDefect.getFailureReason());
+            assertEquals(defect.getSeverityCode(), responseDefect.getSeverityCode());
+            assertEquals(defect.getSeverityDescription(), responseDefect.getSeverityDescription());
+        }
+    }
+}


### PR DESCRIPTION
This adds a new endpoint **/trade/vehicles/annual-tests/** which accepts the parameter **registrations** which allows a user to search up-to 50 VRMs of HGV, PSVs and Trailers.

**registrations** should be entered as a comma separated list.

This new functionality is currently under trial.