### PR TITLE
BL-9581: Removed requirement for DVLA vehicles not to be linked to DVSA vehicles when searching DVLA vehicles

### DIFF
--- a/api/src/main/java/uk/gov/dvsa/mot/persist/jdbc/DvlaVehicleReadSql.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/persist/jdbc/DvlaVehicleReadSql.java
@@ -57,7 +57,6 @@ public class DvlaVehicleReadSql {
             "  LEFT JOIN `make` on `map`.`make_id` = `make`.`id` and `model`.`make_id` = `make`.`id` " +
             "  JOIN `fuel_type` ON `dvla_vehicle`.`propulsion_code` = `fuel_type`.`dvla_propulsion_code` " +
             "WHERE `dvla_vehicle`.`registration` = ? " +
-            "  AND `dvla_vehicle`.`vehicle_id` IS NULL " +
             "ORDER BY `dvla_vehicle`.`last_updated_on` DESC " +
             "LIMIT 1";
 

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeReadServiceDatabase.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeReadServiceDatabase.java
@@ -99,11 +99,11 @@ public class TradeReadServiceDatabase implements TradeReadService {
     }
 
     /*
- * (non-Javadoc)
- *
- * @see uk.gov.dvsa.mot.trade.read.core.TradeReadServiceInterface#
- * getVehiclesByRegistration(String)
- */
+     * (non-Javadoc)
+     *
+     * @see uk.gov.dvsa.mot.trade.read.core.TradeReadServiceInterface#
+     * getVehiclesByRegistration(String)
+     */
     @Override
     @ProvideDbConnection
     public List<uk.gov.dvsa.mot.trade.api.Vehicle> getVehiclesByRegistration(String registration) {


### PR DESCRIPTION
This merge requests fixes in issue where vehicles exist in the DVSA table with no MOT Tests; and the fallback search for DVLA vehicles returns no results (because there is a link to a DVSA vehicle).
 
The fix was to **remove the requirement** when searching for DVLA vehicle, that it must **not** be linked to a DVSA vehicle. After a chat with the database architect, this change has no foreseen issues in regards to performance, or data returned by TradeAPI.