### PR TITLE
BL-9242: Remove ability to query by MOT Test Number

### DIFF
--- a/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
@@ -175,18 +175,6 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
                 logger.debug("Trade API request for vehicle_id = {} returned {} records", decodedVehicleId.toString(), vehicles.size());
                 logger.trace("Exiting getTradeMotTests");
 
-            } else if (number != null) {
-                logger.info("Trade API request for mot test number = {}", number);
-                vehicles = tradeReadService.getVehiclesMotTestsByMotTestNumber(number);
-
-                if (CollectionUtils.isNullOrEmpty(vehicles)) {
-                    throw new InvalidResourceException("No MOT Tests found with number : " + number.toString(),
-                            awsRequestId);
-                }
-
-                logger.debug("Trade API request for mot test number = {}  returned {} records", number, vehicles.size());
-                logger.trace("Exiting getTradeMotTests");
-
             } else if (registration != null) {
                 logger.info("Trade API request for registration {}", registration);
                 vehicles = tradeReadService.getVehiclesByRegistration(registration);

--- a/api/src/main/java/uk/gov/dvsa/mot/persist/TradeReadDao.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/persist/TradeReadDao.java
@@ -9,8 +9,6 @@ public interface TradeReadDao {
 
     List<Vehicle> getVehiclesMotTestsByVehicleId(int vehicleId);
 
-    List<Vehicle> getVehiclesMotTestsByMotTestNumber(long number);
-
     @Deprecated
     List<Vehicle> getVehiclesMotTestsByRegistrationAndMake(String registration, String make);
 

--- a/api/src/main/java/uk/gov/dvsa/mot/persist/jdbc/TradeReadDaoJdbc.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/persist/jdbc/TradeReadDaoJdbc.java
@@ -45,22 +45,6 @@ public class TradeReadDaoJdbc implements TradeReadDao {
     }
 
     @Override
-    public List<Vehicle> getVehiclesMotTestsByMotTestNumber(long number) {
-
-        DbQueryRunner runner = new DbQueryRunnerImpl(connectionManager.getConnection());
-        ResultSetExtractor<List<Vehicle>> mapper = new VehicleResultSetExtractor();
-
-        List<Vehicle> results =
-                runner.executeQuery(TradeReadSql.QUERY_GET_VEHICLES_MOT_TESTS_BY_MOT_TEST_NUMBER, mapper, number, number);
-
-        if (results == null) {
-            return Collections.emptyList();
-        }
-
-        return results;
-    }
-
-    @Override
     @Deprecated
     public List<Vehicle> getVehiclesMotTestsByRegistrationAndMake(String registration, String make) {
 

--- a/api/src/main/java/uk/gov/dvsa/mot/persist/jdbc/TradeReadSql.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/persist/jdbc/TradeReadSql.java
@@ -237,28 +237,6 @@ public class TradeReadSql {
                     + AND + MOT_TEST_VEHICLE_ID_BETWEEN
                     + ORDER_BY_VEHICLE_COMPLETED_MOT_TEST;
 
-    static final String QUERY_GET_VEHICLES_MOT_TESTS_BY_MOT_TEST_NUMBER =
-            SELECT_VEHICLES_MOT_TESTS
-                    + FROM_MOT_TEST_CURRENT
-                    + JOIN_MOT_TEST_CURRENT_RFR_MAP
-                    + JOIN_MOT_TEST_AND_RFR_MAP_DIMENSIONS
-                    + WHERE + MOT_TEST_TYPE_IS_PUBLIC
-                    + AND + MOT_TEST_STATUS_IS_PASS_OR_FAIL
-                    + AND + VEHICLE_REGISTRATION_IS_NOT_INVALID
-                    + AND + VEHICLE_REGISTRATION_NOT_EXCLUDED
-                    + AND + MOT_TEST_NUMBER_EQUALS
-                    + UNION_ALL
-                    + SELECT_VEHICLES_MOT_TESTS
-                    + FROM_MOT_TEST_HISTORY
-                    + JOIN_MOT_TEST_HISTORY_RFR_MAP
-                    + JOIN_MOT_TEST_AND_RFR_MAP_DIMENSIONS
-                    + WHERE + MOT_TEST_TYPE_IS_PUBLIC
-                    + AND + MOT_TEST_STATUS_IS_PASS_OR_FAIL
-                    + AND + VEHICLE_REGISTRATION_IS_NOT_INVALID
-                    + AND + VEHICLE_REGISTRATION_NOT_EXCLUDED
-                    + AND + MOT_TEST_NUMBER_EQUALS
-                    + ORDER_BY_VEHICLE_COMPLETED_MOT_TEST;
-
     static final String QUERY_GET_VEHICLES_MOT_TESTS_BY_VEHICLE_ID =
             SELECT_VEHICLES_MOT_TESTS
                     + FROM_MOT_TEST_CURRENT

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeReadService.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeReadService.java
@@ -14,8 +14,6 @@ public interface TradeReadService {
 
     List<Vehicle> getVehiclesByVehicleId(int id);
 
-    List<Vehicle> getVehiclesMotTestsByMotTestNumber(long number);
-
     List<Vehicle> getVehiclesByRegistrationAndMake(String registration, String make);
 
     List<Vehicle> getVehiclesByRegistration(String registration);

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeReadServiceDatabase.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeReadServiceDatabase.java
@@ -75,19 +75,6 @@ public class TradeReadServiceDatabase implements TradeReadService {
      * (non-Javadoc)
      *
      * @see uk.gov.dvsa.mot.trade.read.core.TradeReadServiceInterface#
-     * getMotTestsByVehicleId1(int)
-     */
-    @Override
-    @ProvideDbConnection
-    public List<uk.gov.dvsa.mot.trade.api.Vehicle> getVehiclesMotTestsByMotTestNumber(long number) {
-
-        return tradeReadDao.getVehiclesMotTestsByMotTestNumber(number);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see uk.gov.dvsa.mot.trade.read.core.TradeReadServiceInterface#
      * getVehiclesByRegistrationAndMake(String,String)
      */
     @Deprecated

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandlerTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandlerTest.java
@@ -255,56 +255,6 @@ public class TradeServiceRequestHandlerTest {
     }
 
     /**
-     * If we ask for an MOT number which doesn't exist we should get an InvalidResourceException.
-     */
-    @Test(expected = InvalidResourceException.class)
-    public void getTradeMotTests_Number_TestDoesNotExist() throws TradeException, ParamObfuscator.ObfuscationException {
-
-        final long motNumber = 42;
-        when(tradeReadService.getVehiclesMotTestsByMotTestNumber(motNumber)).thenReturn(new ArrayList<>());
-
-        request.setNumber(motNumber);
-
-        createHandlerAndGetTradeMotTests(request);
-    }
-
-
-    /**
-     * If we ask for an MOT number which does exist we should get back an appropriate vehicle
-     */
-    @Test
-    public void getTradeMotTests_Number_TestExists() throws TradeException, ParamObfuscator.ObfuscationException {
-
-        final long motNumber = 233432;
-        Vehicle vehicle = new Vehicle();
-        List<Vehicle> vehicles = new ArrayList<>();
-        vehicles.add(vehicle);
-        vehicle.setMotTestNumber(String.valueOf(motNumber));
-        List<VehicleResponse> mappedVehicles = Arrays.asList(new VehicleResponse());
-        when(tradeReadService.getVehiclesMotTestsByMotTestNumber(motNumber)).thenReturn(vehicles);
-        when(vehicleMapper.map(eq(vehicles))).thenReturn(mappedVehicles);
-
-        request.setNumber(motNumber);
-
-        List<?> receivedVehicles = (List<?>) createHandlerAndGetTradeMotTests(request).getEntity();
-
-        assertEquals(mappedVehicles, receivedVehicles);
-    }
-
-    /**
-     * If the database read for an MOT number query throws, we should get an internal server error
-     */
-    @Test(expected = InternalServerErrorException.class)
-    public void getTradeMotTests_Number_DatabaseThrows() throws TradeException, ParamObfuscator.ObfuscationException {
-
-        final long motNumber = 9871234;
-        when(tradeReadService.getVehiclesMotTestsByMotTestNumber(motNumber)).thenThrow(new IndexOutOfBoundsException());
-        request.setNumber(motNumber);
-
-        createHandlerAndGetTradeMotTests(request);
-    }
-
-    /**
      * If we provide only the make, this should result in a BadRequestException as Registration has to come with Make
      */
     @Test(expected = BadRequestException.class)

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/persist/jdbc/TradeReadDaoTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/persist/jdbc/TradeReadDaoTest.java
@@ -157,27 +157,4 @@ public class TradeReadDaoTest {
 
         tradeReadDao.getVehiclesMotTestsByVehicleId(4);
     }
-
-    //@Test
-    public void getVehiclesMotTestsByMotTestNumber_SetsParameters() throws SQLException {
-
-        final long testNumber = 78923;
-
-        when(connectionMock.prepareStatement(TradeReadSql.QUERY_GET_VEHICLES_MOT_TESTS_BY_MOT_TEST_NUMBER))
-                .thenReturn(preparedStatementMock);
-        when(preparedStatementMock.executeQuery()).thenReturn(resultSetMock);
-
-        tradeReadDao.getVehiclesMotTestsByMotTestNumber(testNumber);
-
-        verify(preparedStatementMock).setObject(1, testNumber);
-        verify(preparedStatementMock).setObject(2, testNumber);
-    }
-
-    //@Test(expected = InternalException.class)
-    public void getVehiclesMotTestsByMotTestNumber_ConvertsSqlException() throws SQLException {
-
-        when(connectionMock.prepareStatement(anyString())).thenThrow(new SQLException(""));
-
-        tradeReadDao.getVehiclesMotTestsByMotTestNumber(4);
-    }
 }

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/read/core/TradeReadServiceTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/read/core/TradeReadServiceTest.java
@@ -187,16 +187,6 @@ public class TradeReadServiceTest {
     }
 
     @Test
-    public void getVehiclesMotTestsByMotTestNumber_GetsByGivenNumber() {
-
-        final int testNumber = 7891347;
-
-        tradeReadService.getVehiclesMotTestsByMotTestNumber(testNumber);
-
-        verify(tradeReadDaoMock).getVehiclesMotTestsByMotTestNumber(testNumber);
-    }
-
-    @Test
     public void getVehiclesByRegistrationAndMake_GetsByGivenNumber() {
 
         final String registration = "XX99XXX";


### PR DESCRIPTION
Currently, TradeAPI allows users to search for vehicles/tests by using a MOT Test Number. Security concerns were raised with allowing users to search using a MOT Test Number.

This feature was never documented, and therefore not officially supported.