### PR TITLE
BL-7797: Added annual tests

### DIFF
--- a/api/src/main/java/uk/gov/dvsa/mot/app/ConfigKeys.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/app/ConfigKeys.java
@@ -12,14 +12,13 @@ public final class ConfigKeys {
     public static final String ProxyPort = "PROXY_PORT";
     public static final String LogLevel = "LOG_LEVEL";
 
-    public static final String HgvPsvApiUrl = "HGV_PSV_URL";
-    public static final String HgvPsvApiKeyEncrypted = "HGV_PSV_KEY_ENCRYPTED";
-    public static final String HgvPsvApiConnectionTimeout = "HGV_PSV_CONNECTION_TIMEOUT";
+    public static final String SearchApiUrl = "SEARCH_API_URL";
+    public static final String SearchApiKey = "SEARCH_API_KEY";
+    public static final String SearchApiKeyEncrypted = "SEARCH_API_KEY_ENCRYPTED";
+    public static final String SearchApiConnectionTimeout = "SEARCH_API_CONNECTION_TIMEOUT";
 
     public static final String ObfuscationSecret = "OBFUSCATION_SECRET";
     public static final String ObfuscationEncryptedSecret = "OBFUSCATION_ENCRYPTED_SECRET";
 
-    private ConfigKeys() {
-
-    }
+    public static final String AnnualTestsMaxQueryableRegistrations = "ANNUAL_TESTS_MAX_QUERYABLE_REGISTRATIONS";
 }

--- a/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
@@ -14,16 +14,22 @@ import uk.gov.dvsa.mot.trade.api.BadRequestException;
 import uk.gov.dvsa.mot.trade.api.DisplayMotTestItem;
 import uk.gov.dvsa.mot.trade.api.InternalServerErrorException;
 import uk.gov.dvsa.mot.trade.api.InvalidResourceException;
+import uk.gov.dvsa.mot.trade.api.ServiceTemporarilyUnavailableException;
 import uk.gov.dvsa.mot.trade.api.TradeException;
 import uk.gov.dvsa.mot.trade.api.TradeServiceRequest;
 import uk.gov.dvsa.mot.trade.api.Vehicle;
 import uk.gov.dvsa.mot.trade.api.response.mapper.VehicleResponseMapper;
 import uk.gov.dvsa.mot.trade.api.response.mapper.VehicleResponseMapperFactory;
+import uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle.SearchVehicleResponseMapper;
+import uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle.SearchVehicleResponseMapperFactory;
+import uk.gov.dvsa.mot.trade.read.core.TradeAnnualTestsReadService;
 import uk.gov.dvsa.mot.trade.read.core.TradeReadService;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.StringTokenizer;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -35,6 +41,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import static uk.gov.dvsa.mot.app.ConfigManager.getEnvironmentVariable;
 
 /**
  * Entry point class for Lambdas.
@@ -48,7 +56,9 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
     private static final SimpleDateFormat sdfDate = new SimpleDateFormat("yyyyMMdd");
 
     private TradeReadService tradeReadService;
+    private TradeAnnualTestsReadService tradeAnnualTestsReadService;
     private VehicleResponseMapperFactory vehicleResponseMapperFactory;
+    private SearchVehicleResponseMapperFactory hgvResponseMapperFactory;
 
     public TradeServiceRequestHandler() {
 
@@ -74,10 +84,28 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
         logger.trace("Exiting setTradeReadService");
     }
 
+    /**
+     * Sets the read service for Annual Tests which will be used to make queries required by this class.
+     *
+     * @param tradeAnnualTestsReadService an instance of something which implements {@link TradeAnnualTestsReadService}
+     */
+    @Inject
+    public void setTradeAnnualTestReadService(TradeAnnualTestsReadService tradeAnnualTestsReadService) {
+        logger.trace("Entering setTradeReadService");
+        this.tradeAnnualTestsReadService = tradeAnnualTestsReadService;
+        logger.trace("Exiting setTradeReadService");
+    }
+
     @Inject
     public void setVehicleResponseMapperFactory(VehicleResponseMapperFactory vehicleResponseMapperFactory) {
 
         this.vehicleResponseMapperFactory = vehicleResponseMapperFactory;
+    }
+
+    @Inject
+    public void setHgvResponseMapperFactory(SearchVehicleResponseMapperFactory hgvResponseMapperFactory) {
+
+        this.hgvResponseMapperFactory = hgvResponseMapperFactory;
     }
 
     /**
@@ -145,7 +173,7 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
                     throw e;
                 }
 
-                Integer decodedVehicleId = Integer.parseInt(deobfuscatedVehicleId);
+                int decodedVehicleId = Integer.parseInt(deobfuscatedVehicleId);
                 logger.trace("Decoded vehicle_id to {}", decodedVehicleId);
                 vehicles = tradeReadService.getVehiclesByVehicleId(decodedVehicleId);
 
@@ -155,7 +183,8 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
                             awsRequestId);
                 }
 
-                logger.debug("Trade API request for vehicle_id = {} returned {} records", decodedVehicleId.toString(), vehicles.size());
+                logger.debug("Trade API request for vehicle_id = {} returned {} records",
+                        Integer.toString(decodedVehicleId), vehicles.size());
                 logger.trace("Exiting getTradeMotTests");
 
             } else if (registration != null) {
@@ -213,6 +242,93 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
         } finally {
             logger.trace("Exiting getTradeMotTests");
         }
+    }
+
+    /**
+     * Get HGV/PSV/Trailer Annual Test History as per the provided request, grouped by vehicle.
+     *
+     * @param registrations Query parameter: accepts 1 or more VRMs as a comma separated list.
+     * @return A list of {@link Vehicle}, with each vehicle populated with its annual tests matching the registrations parameters.
+     * @throws TradeException Under various error conditions, including no vehicles are found. It is expected that the surrounding
+     *                        integration will interpret this exception appropriately.
+     */
+    @GET
+    @Path("trade/vehicles/annual-tests")
+    @Produces({
+            MediaType.APPLICATION_JSON,
+            MediaType.WILDCARD,
+            MediaType.APPLICATION_JSON + "+v6"})
+    public Response getTradeAnnualTests(
+            @QueryParam("registrations") String registrations,
+            @javax.ws.rs.core.Context ContainerRequestContext requestContext
+    ) throws TradeException {
+
+        String awsRequestId = null;
+        SearchVehicleResponseMapper mapper = hgvResponseMapperFactory.getMapper(this.parseVersionNumber(requestContext));
+        List<uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle> vehicles;
+
+        try {
+            logger.trace("Entering getAnnualTests");
+            ApiGatewayRequestContext context = (ApiGatewayRequestContext) requestContext.getProperty(
+                    RequestReader.API_GATEWAY_CONTEXT_PROPERTY);
+            if (context != null) {
+                awsRequestId = context.getRequestId();
+            }
+
+            if (registrations != null) {
+
+                int csvMaxQueryableRegistrations =
+                        Integer.parseInt(getEnvironmentVariable(ConfigKeys.AnnualTestsMaxQueryableRegistrations, false));
+
+                if (csvMaxQueryableRegistrations == 0) {
+                    throw new ServiceTemporarilyUnavailableException("Cannot query annual test registrations at this time", awsRequestId);
+                }
+
+                if (registrations.isEmpty()) {
+                    throw new BadRequestException(
+                            "Query parameter 'registrations' expects one or more registrations separated by commas",
+                            awsRequestId
+                    );
+                }
+
+                HashSet<String> requestedRegistrations = parseRegistrations(registrations);
+                if (requestedRegistrations.size() > csvMaxQueryableRegistrations) {
+                    throw new BadRequestException(
+                            String.format("You have defined %d registrations; the limit is %d per request",
+                                    requestedRegistrations.size(),
+                                    csvMaxQueryableRegistrations
+                            ),
+                            awsRequestId
+                    );
+                }
+
+                vehicles = tradeAnnualTestsReadService.getAnnualTests(requestedRegistrations);
+
+                if (CollectionUtils.isNullOrEmpty(vehicles)) {
+                    throw new InvalidResourceException(
+                            String.format("No annual tests found for registrations: %s", registrations),
+                            awsRequestId
+                    );
+                }
+
+            } else {
+                logger.warn("Unrecognised parameter set");
+                throw new BadRequestException("Unrecognised parameter set", awsRequestId);
+            }
+        } catch (TradeException e) {
+            logger.info(e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            // Log unhandled exceptions then throw a 500 Internal Server Error
+            logger.error("Unhandled error has occurred: ", e);
+            throw new InternalServerErrorException(e, awsRequestId);
+        } finally {
+            logger.trace("Exiting getAnnualTests");
+        }
+
+        return Response.ok(mapper.map(vehicles))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     /**
@@ -305,5 +421,37 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
         logger.warn("Accept mime type header not set. TAPI will use default API version");
         logger.trace("Exiting parseVersionNumber");
         return null;
+    }
+
+    /**
+     * This method accepts the query string of VRMs (separated by commas) and parses them into
+     * a trimmed set.
+     *
+     * Bonus of using {@link HashSet} is that it ensures no duplicate VRMs.
+     *
+     * @param registrations VRMs provided as a comma separated list
+     * @return the set of processed VRMs
+     */
+    private HashSet<String> parseRegistrations(String registrations) {
+        HashSet<String> processedRegistrations = new HashSet<>();
+        StringTokenizer st = new StringTokenizer(registrations, ",");
+
+        while (st.hasMoreTokens()) {
+            processedRegistrations.add(
+                    parseRegistration(st.nextToken())
+            );
+        }
+
+        return processedRegistrations;
+    }
+
+    /**
+     * This method will parse the VRM; currently by trimming excess whitespace.
+     *
+     * @param registration the VRM to be parsed
+     * @return parsed/cleaned VRM
+     */
+    private String parseRegistration(String registration) {
+        return registration.trim();
     }
 }

--- a/api/src/main/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTest.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTest.java
@@ -7,6 +7,7 @@ import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
@@ -123,9 +124,8 @@ public class HgvPsvVehicleWithLatestTest implements VehicleWithLatestTest {
     }
 
     private static TestHistory findLatestTest(Vehicle vehicle) {
-        if (vehicle.getTestHistory() != null && vehicle.getTestHistory().length > 0) {
-            TestHistory[] testHistory = vehicle.getTestHistory();
-            return testHistory[testHistory.length - 1];
+        if (vehicle.getTestHistory() != null && !vehicle.getTestHistory().isEmpty()) {
+            return vehicle.getTestHistory().get(vehicle.getTestHistory().size() - 1);
         } else {
             return null;
         }

--- a/api/src/main/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProvider.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProvider.java
@@ -7,11 +7,10 @@ import uk.gov.dvsa.mot.motr.model.HgvPsvVehicleWithLatestTest;
 import uk.gov.dvsa.mot.motr.model.VehicleWithLatestTest;
 import uk.gov.dvsa.mot.trade.api.InvalidResourceException;
 import uk.gov.dvsa.mot.trade.api.TradeException;
-import uk.gov.dvsa.mot.vehicle.hgv.HgvVehicleProvider;
+import uk.gov.dvsa.mot.vehicle.hgv.SearchVehicleProvider;
 import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 import uk.gov.dvsa.mot.vehicle.hgv.validation.TrailerIdFormat;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -22,12 +21,12 @@ public class MotrVehicleHistoryProvider {
     private static final Logger logger = LogManager.getLogger(MotrVehicleHistoryProvider.class);
 
     private MotrReadService motrReadService;
-    private HgvVehicleProvider hgvVehicleProvider;
+    private SearchVehicleProvider searchVehicleProvider;
 
     @Inject
-    public MotrVehicleHistoryProvider(MotrReadService motrReadService, HgvVehicleProvider hgvVehicleProvider) {
+    public MotrVehicleHistoryProvider(MotrReadService motrReadService, SearchVehicleProvider searchVehicleProvider) {
         this.motrReadService = motrReadService;
-        this.hgvVehicleProvider = hgvVehicleProvider;
+        this.searchVehicleProvider = searchVehicleProvider;
     }
 
     @NotNull public VehicleWithLatestTest searchVehicleByRegistration(@NotNull String registration) throws Exception {
@@ -42,7 +41,7 @@ public class MotrVehicleHistoryProvider {
         if (shouldGetHgvPsvHistory(optionalDvlaVehicle.isPresent(), registration)) {
             logger.trace("Fetching HGV/PSV test history for registration: {}", registration);
 
-            Optional<Vehicle> optionalHgvPsvVehicle = Optional.ofNullable(hgvVehicleProvider.getVehicle(registration));
+            Optional<Vehicle> optionalHgvPsvVehicle = Optional.ofNullable(searchVehicleProvider.getVehicle(registration));
 
             if (optionalHgvPsvVehicle.isPresent()) {
                 logger.debug("HGV/PSV history found for registration: {}", registration);
@@ -67,7 +66,7 @@ public class MotrVehicleHistoryProvider {
 
         if (shouldGetHgvPsvHistory(dvlaVehicleOptional.isPresent(), registration)) {
 
-            Vehicle hgvPsvVehicle = hgvVehicleProvider.getVehicle(registration);
+            Vehicle hgvPsvVehicle = searchVehicleProvider.getVehicle(registration);
 
             if (hgvPsvVehicle != null) {
                 return new HgvPsvVehicleWithLatestTest(hgvPsvVehicle,
@@ -107,7 +106,7 @@ public class MotrVehicleHistoryProvider {
             return motVehicle;
         }
 
-        Vehicle hgvVehicle = hgvVehicleProvider.getVehicle(motVehicle.getRegistration());
+        Vehicle hgvVehicle = searchVehicleProvider.getVehicle(motVehicle.getRegistration());
         if (hgvVehicle == null) {
             logger.debug("No HGV/PSV history found for registration{}", motVehicle.getRegistration());
             return motVehicle;

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/ServiceTemporarilyUnavailableException.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/ServiceTemporarilyUnavailableException.java
@@ -1,0 +1,10 @@
+package uk.gov.dvsa.mot.trade.api;
+
+public class ServiceTemporarilyUnavailableException extends TradeException {
+    private static final long serialVersionUID = 1L;
+
+    public ServiceTemporarilyUnavailableException(String message, String awsRequestId) {
+
+        super("Service Temporarily Unavailable", 503, message, awsRequestId);
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/TradeServiceRequest.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/TradeServiceRequest.java
@@ -9,6 +9,7 @@ public class TradeServiceRequest {
     private Header[] header;
     private MotTestQueryParams queryParams = new MotTestQueryParams();
     private MotTestPathParams pathParams = new MotTestPathParams();
+    private AnnualTestQueryParams annualTestQueryParams = new AnnualTestQueryParams();
 
     private String requestId;
 
@@ -20,6 +21,7 @@ public class TradeServiceRequest {
                 ", header=" + Arrays.toString(header) +
                 ", queryParams=" + queryParams +
                 ", pathParams=" + pathParams +
+                ", annualTestQueryParams=" + annualTestQueryParams +
                 '}';
     }
 
@@ -71,6 +73,16 @@ public class TradeServiceRequest {
     public void setHeader(Header[] header) {
 
         this.header = header;
+    }
+
+    public AnnualTestQueryParams getAnnualTestQueryParams() {
+
+        return annualTestQueryParams;
+    }
+
+    public void setAnnualTestQueryParams(AnnualTestQueryParams annualTestQueryParams) {
+
+        this.annualTestQueryParams = annualTestQueryParams;
     }
 
     public MotTestQueryParams getQueryParams() {
@@ -138,6 +150,16 @@ public class TradeServiceRequest {
     public void setRegistration(String registration) {
 
         queryParams.registration = registration;
+    }
+
+    public String getAnnualTestsRegistrations() {
+
+        return annualTestQueryParams.registrations;
+    }
+
+    public void setAnnualTestsRegistrations(String registrations) {
+
+        annualTestQueryParams.registrations = registrations;
     }
 
     public String getMake() {
@@ -378,6 +400,27 @@ public class TradeServiceRequest {
                     ", number=" + number +
                     ", registration='" + registration + '\'' +
                     ", make='" + make + '\'' +
+                    '}';
+        }
+    }
+
+    public class AnnualTestQueryParams {
+
+        private String registrations;
+
+        public String getRegistrations() {
+            return registrations;
+        }
+
+        public void setRegistrations(String registrations) {
+            this.registrations = registrations;
+        }
+
+        @Override
+        public String toString() {
+
+            return "AnnualTestQueryParams{" +
+                    " registrations='" + registrations + '\'' +
                     '}';
         }
     }

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapper.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapper.java
@@ -1,0 +1,52 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleResponse;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public abstract class SearchVehicleResponseMapper {
+
+    private static final String SEARCH_API_DATE_PATTERN = "d/M/yyyy";
+    private static final String TRADE_API_DATE_PATTERN = "yyyy.MM.dd";
+
+    public abstract List<SearchVehicleResponse> map(List<Vehicle> vehicles);
+
+    protected void fillBaseVehicleResponseProperties(SearchVehicleResponse searchVehicleResponse, Vehicle vehicle) {
+        searchVehicleResponse.setRegistration(vehicle.getVehicleIdentifier());
+        searchVehicleResponse.setMake(vehicle.getMake());
+        searchVehicleResponse.setModel(vehicle.getModel());
+        searchVehicleResponse.setManufactureDate(transformDate(vehicle.getManufactureDate()));
+        searchVehicleResponse.setVehicleType(vehicle.getVehicleType());
+        searchVehicleResponse.setVehicleClass(vehicle.getVehicleClass());
+        searchVehicleResponse.setRegistrationDate(transformDate(vehicle.getRegistrationDate()));
+    }
+
+    protected void fillBaseTestResponseProperties(AnnualTestResponse annualTestResponse, TestHistory testHistory) {
+        annualTestResponse.setTestDate(transformDate(testHistory.getTestDate()));
+        annualTestResponse.setTestType(testHistory.getTestType());
+        annualTestResponse.setTestResult(testHistory.getTestResult());
+        annualTestResponse.setTestCertificateNumber(testHistory.getTestCertificateSerialNo());
+        annualTestResponse.setExpiryDate(transformDate(testHistory.getTestCertificateExpiryDateAtTest()));
+        annualTestResponse.setNumberOfDefectsAtTest(testHistory.getNumberOfDefectsAtTest().toString());
+        annualTestResponse.setNumberOfAdvisoryDefectsAtTest(testHistory.getNumberOfAdvisoryDefectsAtTest().toString());
+    }
+
+    protected String transformDate(String searchApiDate) {
+
+        if (searchApiDate == null) {
+            return null;
+        }
+
+        LocalDate date = LocalDate.parse(
+                searchApiDate,
+                DateTimeFormatter.ofPattern(SEARCH_API_DATE_PATTERN)
+        );
+
+        return date.format(DateTimeFormatter.ofPattern(TRADE_API_DATE_PATTERN));
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapperFactory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapperFactory.java
@@ -1,0 +1,33 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SearchVehicleResponseMapperFactory {
+    private static final Logger logger = LogManager.getLogger(SearchVehicleResponseMapperFactory.class);
+
+    public SearchVehicleResponseMapper getMapper(String version) {
+
+        logger.trace("Entering SearchVehicleResponseMapperFactory.getMapper");
+        SearchVehicleResponseMapper mapper;
+
+        if (version == null) {
+            logger.debug("API version requested is null, using v6");
+            mapper = new SearchVehicleV6ResponseMapper();
+        } else {
+            switch (version) {
+                case "v6":
+                    mapper = new SearchVehicleV6ResponseMapper();
+                    break;
+                default:
+                    logger.warn("Unknown API version selected. Using v6");
+                    mapper = new SearchVehicleV6ResponseMapper();
+            }
+        }
+
+        logger.debug("Mapper version selected: " + mapper.getClass().getSimpleName());
+        logger.trace("Exiting SearchVehicleResponseMapperFactory.getMapper");
+        return mapper;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleTestTypeMapFilter.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleTestTypeMapFilter.java
@@ -1,0 +1,61 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class provides functionality to determine if a {@link TestHistory} object is
+ * whitelisted for display in a result set.
+ */
+public class SearchVehicleTestTypeMapFilter {
+
+    private static final List<String> visibleTestTypes = new ArrayList<>(
+            Arrays.asList(
+                    "1ST PAID RETEST",
+                    "1ST PG9 FULL INSPECTION & FEE",
+                    "1ST PG9 FULL INSPECTION & FEE",
+                    "1ST PG9 PAID RETEST",
+                    "1ST TEST MV",
+                    "1ST TEST TRAILER",
+                    "1ST TEST TRI AXLE FREE RETEST",
+                    "6A PG9 + S/BELT PAID RETEST",
+                    "6A PG9 FULL INSP & FEE + SBELT",
+                    "ANNUAL MV",
+                    "ANNUAL PSV LARGE",
+                    "ANNUAL PSV SMALL",
+                    "ANNUAL TEST HAULAGE VEHICLE",
+                    "ANNUAL TRAILER",
+                    "ARTIC BUS ANNUAL TEST LARGE",
+                    "ARTIC BUS FULLY PAID RETEST",
+                    "ARTIC BUS PART PAID RETEST",
+                    "CLASS 6A ANNUAL",
+                    "CLASS 6A FIRST TEST",
+                    "CLASS 6A PAID RETEST",
+                    "COIF + S/BELT + TEST CERT",
+                    "COIF + TEST CERTIFICATE",
+                    "COIF PAID RETEST + TEST CERT",
+                    "COIF+S/BELT PAID RETEST + CERT",
+                    "FIRST TEST HAULAGE VEHICLE",
+                    "PAID RETEST",
+                    "PAID RETEST HAULAGE VEHICLE",
+                    "PART PAID RETEST",
+                    "PG9 FULL INSPECTION & FEE",
+                    "PG9 PAID RETEST",
+                    "PG9 PART PAID RETEST",
+                    "TRI AXLE FREE RETEST"
+            ));
+
+    /**
+     * This method will determine if the {@link TestHistory} provided has the test type
+     * that is whitelisted for inclusion in a result set.
+     *
+     * @param testHistory the test that is being verified.
+     * @return boolean
+     */
+    public static boolean canDisplayTest(TestHistory testHistory) {
+        return visibleTestTypes.contains(testHistory.getTestType());
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV6ResponseMapper.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV6ResponseMapper.java
@@ -1,0 +1,69 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import uk.gov.dvsa.mot.app.util.CollectionUtils;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestV1Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectV1Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleV1Response;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+
+public class SearchVehicleV6ResponseMapper extends SearchVehicleResponseMapper {
+
+    public List<SearchVehicleResponse> map(List<Vehicle> vehicles) {
+        return vehicles.stream().map(this::mapVehicle).collect(Collectors.toList());
+    }
+
+    private SearchVehicleResponse mapVehicle(Vehicle vehicle) {
+        SearchVehicleV1Response vehicleResponse = new SearchVehicleV1Response();
+        this.fillBaseVehicleResponseProperties(vehicleResponse, vehicle);
+        vehicleResponse.setAnnualTestExpiryDate(transformDate(vehicle.getTestCertificateExpiryDate()));
+
+        if (!CollectionUtils.isNullOrEmpty(vehicle.getTestHistory())) {
+            vehicleResponse.setAnnualTests(
+                    vehicle.getTestHistory()
+                            .stream()
+                            .map(this::mapTest)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList())
+            );
+        }
+
+        return vehicleResponse;
+    }
+
+    private AnnualTestResponse mapTest(TestHistory testHistory) {
+        if (!SearchVehicleTestTypeMapFilter.canDisplayTest(testHistory)) {
+            return null;
+        }
+
+        AnnualTestV1Response annualTestResponse = new AnnualTestV1Response();
+        this.fillBaseTestResponseProperties(annualTestResponse, testHistory);
+
+        if (!CollectionUtils.isNullOrEmpty(testHistory.getTestHistoryDefects())) {
+            annualTestResponse.setDefects(
+                    testHistory.getTestHistoryDefects().stream().map(this::mapDefect).collect(Collectors.toList())
+            );
+        }
+
+        return annualTestResponse;
+    }
+
+    private DefectResponse mapDefect(Defect defectItem) {
+        DefectV1Response defectResponse = new DefectV1Response();
+        defectResponse.setFailureItemNo(defectItem.getFailureItemNo());
+        defectResponse.setSeverityCode(defectItem.getSeverityCode());
+        defectResponse.setSeverityDescription(defectItem.getSeverityDescription());
+        defectResponse.setFailureReason(defectItem.getFailureReason());
+
+        return defectResponse;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/AnnualTestResponse.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/AnnualTestResponse.java
@@ -1,0 +1,82 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class AnnualTestResponse {
+
+    private String testDate;
+    private String testType;
+    private String testResult;
+    private String testCertificateNumber;
+    private String expiryDate;
+    private String numberOfDefectsAtTest;
+    private String numberOfAdvisoryDefectsAtTest;
+    private List<DefectResponse> defects;
+
+    public String getTestDate() {
+        return testDate;
+    }
+
+    public void setTestDate(String testDate) {
+        this.testDate = testDate;
+    }
+
+    public String getTestType() {
+        return testType;
+    }
+
+    public void setTestType(String testType) {
+        this.testType = testType;
+    }
+
+    public String getTestResult() {
+        return testResult;
+    }
+
+    public void setTestResult(String testResult) {
+        this.testResult = testResult;
+    }
+
+    public String getTestCertificateNumber() {
+        return testCertificateNumber;
+    }
+
+    public void setTestCertificateNumber(String testCertificateNumber) {
+        this.testCertificateNumber = testCertificateNumber;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public String getNumberOfDefectsAtTest() {
+        return numberOfDefectsAtTest;
+    }
+
+    public void setNumberOfDefectsAtTest(String numberOfDefectsAtTest) {
+        this.numberOfDefectsAtTest = numberOfDefectsAtTest;
+    }
+
+    public String getNumberOfAdvisoryDefectsAtTest() {
+        return numberOfAdvisoryDefectsAtTest;
+    }
+
+    public void setNumberOfAdvisoryDefectsAtTest(String numberOfAdvisoryDefectsAtTest) {
+        this.numberOfAdvisoryDefectsAtTest = numberOfAdvisoryDefectsAtTest;
+    }
+
+    public List<DefectResponse> getDefects() {
+        return defects;
+    }
+
+    public void setDefects(List<DefectResponse> defects) {
+        this.defects = defects;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/AnnualTestV1Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/AnnualTestV1Response.java
@@ -1,0 +1,8 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class AnnualTestV1Response extends AnnualTestResponse {
+    // No changes for version 1
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/DefectResponse.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/DefectResponse.java
@@ -1,0 +1,48 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class DefectResponse {
+
+    private String failureItemNo;
+    private String failureReason;
+    private String severityCode;
+    private String severityDescription;
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public String getFailureItemNo() {
+        return failureItemNo;
+    }
+
+    public void setFailureItemNo(Integer failureItemNo) {
+        if (failureItemNo != null) {
+            this.failureItemNo = failureItemNo.toString();
+            return;
+        }
+        this.failureItemNo = null;
+    }
+
+    public String getSeverityCode() {
+        return severityCode;
+    }
+
+    public void setSeverityCode(String severityCode) {
+        this.severityCode = severityCode;
+    }
+
+    public String getSeverityDescription() {
+        return severityDescription;
+    }
+
+    public void setSeverityDescription(String severityDescription) {
+        this.severityDescription = severityDescription;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/DefectV1Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/DefectV1Response.java
@@ -1,0 +1,8 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class DefectV1Response extends DefectResponse {
+    // No changes for version 1
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/SearchVehicleResponse.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/SearchVehicleResponse.java
@@ -1,0 +1,91 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class SearchVehicleResponse {
+
+    private String registration;
+    private String make;
+    private String model;
+    private String manufactureDate;
+    private String vehicleType;
+    private String vehicleClass;
+    private String registrationDate;
+    private String annualTestExpiryDate;
+    private List<AnnualTestResponse> annualTests;
+
+    public String getRegistration() {
+        return registration;
+    }
+
+    public void setRegistration(String registration) {
+        this.registration = registration;
+    }
+
+    public String getMake() {
+        return make;
+    }
+
+    public void setMake(String make) {
+        this.make = make;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getManufactureDate() {
+        return manufactureDate;
+    }
+
+    public void setManufactureDate(String manufactureDate) {
+        this.manufactureDate = manufactureDate;
+    }
+
+    public String getVehicleType() {
+        return vehicleType;
+    }
+
+    public void setVehicleType(String vehicleType) {
+        this.vehicleType = vehicleType;
+    }
+
+    public String getVehicleClass() {
+        return vehicleClass;
+    }
+
+    public void setVehicleClass(String vehicleClass) {
+        this.vehicleClass = vehicleClass;
+    }
+
+    public String getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(String registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    public List<AnnualTestResponse> getAnnualTests() {
+        return annualTests;
+    }
+
+    public void setAnnualTests(List<AnnualTestResponse> annualTests) {
+        this.annualTests = annualTests;
+    }
+
+    public String getAnnualTestExpiryDate() {
+        return annualTestExpiryDate;
+    }
+
+    public void setAnnualTestExpiryDate(String annualTestExpiryDate) {
+        this.annualTestExpiryDate = annualTestExpiryDate;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/SearchVehicleV1Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/SearchVehicleV1Response.java
@@ -1,0 +1,8 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class SearchVehicleV1Response extends SearchVehicleResponse {
+    // No changes for version 1
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeAnnualTestsReadService.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/read/core/TradeAnnualTestsReadService.java
@@ -1,0 +1,61 @@
+package uk.gov.dvsa.mot.trade.read.core;
+
+import com.google.inject.Inject;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import uk.gov.dvsa.mot.vehicle.hgv.SearchVehicleProvider;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TradeAnnualTestsReadService {
+
+    private static final Logger logger = LogManager.getLogger(TradeAnnualTestsReadService.class);
+
+    private SearchVehicleProvider searchVehicleProvider;
+
+    /**
+     * Sets the search vehicle provider which will be used to make queries required by this class.
+     *
+     * @param searchVehicleProvider an instance of something which implements {@link SearchVehicleProvider}
+     */
+    @Inject
+    public void setSearchVehicleProvider(SearchVehicleProvider searchVehicleProvider) {
+
+        this.searchVehicleProvider = searchVehicleProvider;
+    }
+
+    /**
+     * This method will iterate over a collection of VRMs and query SearchAPI.
+     *
+     * Vehicles found are added to the result set which is returned after iteration.
+     *
+     * @param requestedRegistrations collection of VRMs to query SearchAPI
+     * @return collection of vehicles found on SearchAPI.
+     * @throws Exception
+     */
+    public List<Vehicle> getAnnualTests(Collection<String> requestedRegistrations) throws Exception {
+        logger.trace("Entering getAnnualTests");
+        List<Vehicle> vehicleList = new ArrayList<>();
+
+        for (String registration: requestedRegistrations) {
+            if (registration.isEmpty()) {
+                logger.trace("Empty registration, skipping...");
+                continue;
+            }
+            logger.debug("Querying search api for registration {}", registration);
+            Vehicle vehicle = searchVehicleProvider.getVehicle(registration);
+
+            if (vehicle != null) {
+                logger.trace("Vehicle with registration {} found. Appending to result...", registration);
+                vehicleList.add(vehicle);
+            }
+        }
+        logger.trace("Exiting getAnnualTests");
+        return vehicleList;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/SearchConfiguration.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/SearchConfiguration.java
@@ -7,7 +7,7 @@ import uk.gov.dvsa.mot.app.ConfigManager;
 
 import java.io.IOException;
 
-public class HgvConfiguration {
+public class SearchConfiguration {
 
     private static String apiKey;
 
@@ -16,15 +16,18 @@ public class HgvConfiguration {
     private String proxyHost;
     private String proxyPort;
 
-    public HgvConfiguration() throws IOException {
+    public SearchConfiguration() throws IOException {
 
-        // if api key is not already set
         if (StringUtils.isNullOrEmpty(apiKey)) {
-            apiKey = ConfigManager.getEnvironmentVariable(ConfigKeys.HgvPsvApiKeyEncrypted);
+            apiKey = ConfigManager.getEnvironmentVariable(ConfigKeys.SearchApiKey);
         }
 
-        this.apiUrl = ConfigManager.getEnvironmentVariable(ConfigKeys.HgvPsvApiUrl);
-        this.timeoutInSeconds = Integer.parseInt(ConfigManager.getEnvironmentVariable(ConfigKeys.HgvPsvApiConnectionTimeout));
+        if (StringUtils.isNullOrEmpty(apiKey)) {
+            apiKey = ConfigManager.getEnvironmentVariable(ConfigKeys.SearchApiKeyEncrypted);
+        }
+
+        this.apiUrl = ConfigManager.getEnvironmentVariable(ConfigKeys.SearchApiUrl);
+        this.timeoutInSeconds = Integer.parseInt(ConfigManager.getEnvironmentVariable(ConfigKeys.SearchApiConnectionTimeout));
         this.proxyHost = ConfigManager.getEnvironmentVariable(ConfigKeys.ProxyHost);
         this.proxyPort = ConfigManager.getEnvironmentVariable(ConfigKeys.ProxyPort);
     }

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Defect.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Defect.java
@@ -1,0 +1,62 @@
+package uk.gov.dvsa.mot.vehicle.hgv.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Defect {
+
+    private Integer failureItemNo;
+    private String severityCode;
+    private String severityDescription;
+    private String failureReason;
+    private String defectCode;
+    private String defectDescription;
+
+    public Integer getFailureItemNo() {
+        return failureItemNo;
+    }
+
+    public void setFailureItemNo(Integer failureItemNo) {
+        this.failureItemNo = failureItemNo;
+    }
+
+    public String getSeverityCode() {
+        return severityCode;
+    }
+
+    public void setSeverityCode(String severityCode) {
+        this.severityCode = severityCode;
+    }
+
+    public String getSeverityDescription() {
+        return severityDescription;
+    }
+
+    public void setSeverityDescription(String severityDescription) {
+        this.severityDescription = severityDescription;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public String getDefectCode() {
+        return defectCode;
+    }
+
+    public void setDefectCode(String defectCode) {
+        this.defectCode = defectCode;
+    }
+
+    public String getDefectDescription() {
+        return defectDescription;
+    }
+
+    public void setDefectDescription(String defectDescription) {
+        this.defectDescription = defectDescription;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/TestHistory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/TestHistory.java
@@ -2,6 +2,10 @@ package uk.gov.dvsa.mot.vehicle.hgv.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.annotation.JSONP;
+
+import java.util.List;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestHistory {
     private String testType;
@@ -13,6 +17,7 @@ public class TestHistory {
     private Integer numberOfAdvisoryDefectsAtTest;
     private String vehicleIdentifierAtTest;
     private String testCertificateSerialNo;
+    private List<Defect> testHistoryDefects;
 
     public String getTestType() {
         return testType;
@@ -84,5 +89,13 @@ public class TestHistory {
 
     public void setVehicleIdentifierAtTest(String vehicleIdentifierAtTest) {
         this.vehicleIdentifierAtTest = vehicleIdentifierAtTest;
+    }
+
+    public List<Defect> getTestHistoryDefects() {
+        return testHistoryDefects;
+    }
+
+    public void setTestHistoryDefects(List<Defect> defects) {
+        this.testHistoryDefects = defects;
     }
 }

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Vehicle.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/model/Vehicle.java
@@ -2,9 +2,11 @@ package uk.gov.dvsa.mot.vehicle.hgv.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.util.List;
+
 public class Vehicle {
     @JsonIgnore
-    private TestHistory[] testHistory;
+    private List<TestHistory> testHistory;
     private String vehicleClass;
     private String vehicleType;
     private String chassisType;
@@ -19,11 +21,11 @@ public class Vehicle {
     private String make;
     private String model;
 
-    public void setTestHistory(TestHistory[] testHistory) {
+    public void setTestHistory(List<TestHistory> testHistory) {
         this.testHistory = testHistory;
     }
 
-    public TestHistory[] getTestHistory() {
+    public List<TestHistory> getTestHistory() {
         return testHistory;
     }
 

--- a/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/response/ResponseTestHistory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/vehicle/hgv/response/ResponseTestHistory.java
@@ -3,14 +3,17 @@ package uk.gov.dvsa.mot.vehicle.hgv.response;
 
 import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
 
-public class ResponseTestHistory {
-    TestHistory[] testHistory;
+import java.util.List;
 
-    public TestHistory[] getTestHistory() {
+public class ResponseTestHistory {
+
+    List<TestHistory> testHistory;
+
+    public List<TestHistory> getTestHistory() {
         return testHistory;
     }
 
-    public void setTestHistory(TestHistory[] testHistory) {
+    public void setTestHistory(List<TestHistory> testHistory) {
         this.testHistory = testHistory;
     }
 }

--- a/api/src/test/integration/java/uk/gov/dvsa/mot/app/MotrRequestHandlerTest.java
+++ b/api/src/test/integration/java/uk/gov/dvsa/mot/app/MotrRequestHandlerTest.java
@@ -72,12 +72,12 @@ public class MotrRequestHandlerTest {
     }
 
     private void setSystemProperties() {
-        setPropertyIfMissing(ConfigKeys.HgvPsvApiConnectionTimeout, "100");
+        setPropertyIfMissing(ConfigKeys.SearchApiConnectionTimeout, "100");
         setPropertyIfMissing(ConfigKeys.DatabaseConnection, "jdbc:mysql://127.0.0.1:3306/mot2");
         setPropertyIfMissing(ConfigKeys.DatabaseUsername, "motdbuser");
         setPropertyIfMissing(ConfigKeys.DatabasePassword, "password");
-        setPropertyIfMissing(ConfigKeys.HgvPsvApiUrl, "http://localhost:3000");
-        setPropertyIfMissing(ConfigKeys.HgvPsvApiKeyEncrypted, "key");
+        setPropertyIfMissing(ConfigKeys.SearchApiUrl, "http://localhost:3000");
+        setPropertyIfMissing(ConfigKeys.SearchApiKeyEncrypted, "key");
     }
 
     private void setPropertyIfMissing(String key, String value) {

--- a/api/src/test/integration/java/uk/gov/dvsa/mot/app/motr/MotrHandlerAbstractTest.java
+++ b/api/src/test/integration/java/uk/gov/dvsa/mot/app/motr/MotrHandlerAbstractTest.java
@@ -7,7 +7,6 @@ import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import org.junit.Before;
-import org.junit.Test;
 
 import uk.gov.dvsa.mot.app.ConfigKeys;
 import uk.gov.dvsa.mot.app.LambdaHandler;
@@ -42,12 +41,12 @@ public abstract class MotrHandlerAbstractTest {
     }
 
     private void setSystemProperties() {
-        setPropertyIfMissing(ConfigKeys.HgvPsvApiConnectionTimeout, "100");
+        setPropertyIfMissing(ConfigKeys.SearchApiConnectionTimeout, "100");
         setPropertyIfMissing(ConfigKeys.DatabaseConnection, "jdbc:mysql://127.0.0.1:3306/mot2");
         setPropertyIfMissing(ConfigKeys.DatabaseUsername, "motdbuser");
         setPropertyIfMissing(ConfigKeys.DatabasePassword, "password");
-        setPropertyIfMissing(ConfigKeys.HgvPsvApiUrl, "http://localhost:3000");
-        setPropertyIfMissing(ConfigKeys.HgvPsvApiKeyEncrypted, "key");
+        setPropertyIfMissing(ConfigKeys.SearchApiUrl, "http://localhost:3000");
+        setPropertyIfMissing(ConfigKeys.SearchApiKeyEncrypted, "key");
     }
 
     private void setPropertyIfMissing(String key, String value) {

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTestTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/motr/model/HgvPsvVehicleWithLatestTestTest.java
@@ -7,6 +7,8 @@ import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -68,11 +70,11 @@ public class HgvPsvVehicleWithLatestTestTest {
     }
 
     private Vehicle createVehicleWithTestHistory(String vehicleType) {
-        TestHistory[] testHistory = new TestHistory[1];
+        List<TestHistory> testHistory = new ArrayList<>();
         TestHistory historyItem =  new TestHistory();
         historyItem.setTestCertificateSerialNo(TEST_NUMBER);
         historyItem.setTestDate("03/01/2013");
-        testHistory[0] = historyItem;
+        testHistory.add(historyItem);
 
         Vehicle vehicle = createVehicle(vehicleType);
         vehicle.setTestHistory(testHistory);

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProviderTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProviderTest.java
@@ -12,13 +12,15 @@ import uk.gov.dvsa.mot.motr.model.VehicleType;
 import uk.gov.dvsa.mot.motr.model.VehicleWithLatestTest;
 import uk.gov.dvsa.mot.mottest.api.MotTest;
 import uk.gov.dvsa.mot.trade.api.InvalidResourceException;
-import uk.gov.dvsa.mot.vehicle.hgv.HgvVehicleProvider;
+import uk.gov.dvsa.mot.vehicle.hgv.SearchVehicleProvider;
 import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
 import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Optional;
 
 import static com.googlecode.catchexception.CatchException.catchException;
@@ -45,7 +47,7 @@ public class MotrVehicleHistoryProviderTest {
     private MotrReadService motrReadService;
 
     @Mock
-    private HgvVehicleProvider hgvVehicleProvider;
+    private SearchVehicleProvider searchVehicleProvider;
 
     private MotrVehicleHistoryProvider motrVehicleHistoryProvider;
 
@@ -53,7 +55,7 @@ public class MotrVehicleHistoryProviderTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        motrVehicleHistoryProvider = new MotrVehicleHistoryProvider(motrReadService, hgvVehicleProvider);
+        motrVehicleHistoryProvider = new MotrVehicleHistoryProvider(motrReadService, searchVehicleProvider);
     }
 
     @Test
@@ -77,7 +79,7 @@ public class MotrVehicleHistoryProviderTest {
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(Optional.empty());
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(dvlaVehicle);
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(null);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(null);
 
         catchException(motrVehicleHistoryProvider).searchVehicleByRegistration(REGISTRATION);
 
@@ -117,7 +119,7 @@ public class MotrVehicleHistoryProviderTest {
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(Optional.empty());
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(dvlaVehicle);
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
 
         VehicleWithLatestTest result = motrVehicleHistoryProvider.searchVehicleByRegistration(REGISTRATION);
 
@@ -137,11 +139,14 @@ public class MotrVehicleHistoryProviderTest {
         hgvPsvVehicle.setTestCertificateExpiryDate("01/03/2018");
         TestHistory historyItem = new TestHistory();
         historyItem.setTestDate("02/02/2017");
-        hgvPsvVehicle.setTestHistory(new TestHistory[] { historyItem });
+
+        List<TestHistory> testHistory = new ArrayList<>();
+        testHistory.add(historyItem);
+        hgvPsvVehicle.setTestHistory(testHistory);
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(motVehicle);
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(Optional.empty());
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
 
         VehicleWithLatestTest result = motrVehicleHistoryProvider.searchVehicleByRegistration(REGISTRATION);
 
@@ -161,7 +166,7 @@ public class MotrVehicleHistoryProviderTest {
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(motVehicle);
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(Optional.empty());
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
 
         VehicleWithLatestTest result = motrVehicleHistoryProvider.searchVehicleByRegistration(REGISTRATION);
 
@@ -181,7 +186,7 @@ public class MotrVehicleHistoryProviderTest {
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(motVehicle);
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(Optional.empty());
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
 
         VehicleWithLatestTest result = motrVehicleHistoryProvider.searchVehicleByRegistration(REGISTRATION);
 
@@ -208,7 +213,7 @@ public class MotrVehicleHistoryProviderTest {
         uk.gov.dvsa.mot.trade.api.DvlaVehicle dvlaVehicleEntity = new uk.gov.dvsa.mot.trade.api.DvlaVehicle();
         Optional<VehicleWithLatestTest> dvlaVehicle = Optional.of(new DvlaVehicle(dvlaVehicleEntity, null));
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(dvlaVehicle);
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(null);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(null);
 
         catchException(motrVehicleHistoryProvider).searchForCommercialVehicleByRegistration(REGISTRATION);
 
@@ -227,7 +232,7 @@ public class MotrVehicleHistoryProviderTest {
 
         when(motrReadService.getLatestMotTestByRegistration(REGISTRATION)).thenReturn(Optional.empty());
         when(motrReadService.getLatestMotTestForDvlaVehicleByRegistration(REGISTRATION)).thenReturn(dvlaVehicle);
-        when(hgvVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
+        when(searchVehicleProvider.getVehicle(eq(REGISTRATION))).thenReturn(hgvPsvVehicle);
 
         VehicleWithLatestTest result = motrVehicleHistoryProvider.searchForCommercialVehicleByRegistration(REGISTRATION);
 

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/MockVehicleDataHelper.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/MockVehicleDataHelper.java
@@ -3,8 +3,12 @@ package uk.gov.dvsa.mot.trade.api.response.mapper;
 import uk.gov.dvsa.mot.trade.api.MotTest;
 import uk.gov.dvsa.mot.trade.api.RfrAndAdvisoryItem;
 import uk.gov.dvsa.mot.trade.api.Vehicle;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class MockVehicleDataHelper {
     public static final String DEFICIENCY_CATEGORY_TYPE_PRE_EU = "PE";
@@ -78,5 +82,119 @@ public class MockVehicleDataHelper {
         rfr.setDeficiencyCategoryDescription("Major");
 
         return rfr;
+    }
+
+    public static uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle getSearchVehicleContainingSpecificTestType(
+            String vehicleType, List<String> testTypes) {
+
+        uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle = getSearchVehicle(vehicleType, true);
+
+        vehicle.getTestHistory().clear();
+
+        for (String testType: testTypes) {
+            vehicle.getTestHistory().add(getSearchTest(2000, true, vehicle, testType));
+        }
+
+        return vehicle;
+    }
+
+    public static uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle getSearchVehicle(String vehicleType, boolean hasTests) {
+
+        uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle = new uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle();
+
+        vehicle.setVehicleIdentifier(vehicleType + "REG123");
+        vehicle.setMake("Some" + vehicleType + "Make");
+        vehicle.setModel("Some" + vehicleType + "Model");
+        vehicle.setManufactureDate("30/12/2003");
+        vehicle.setVehicleType(vehicleType);
+        vehicle.setVehicleClass("V");
+        vehicle.setRegistrationDate("30/06/2003");
+        vehicle.setTestCertificateExpiryDate("09/03/2019");
+
+        if (hasTests) {
+            List<TestHistory> testHistory = new ArrayList<>();
+            testHistory.add(getSearchTest(2010, true, vehicle));
+            testHistory.add(getSearchTest(2009, false, vehicle));
+            vehicle.setTestHistory(testHistory);
+        }
+
+        return vehicle;
+    }
+
+    public static TestHistory getSearchTest(int year, boolean passed, uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle, String testType) {
+        TestHistory testHistory = getSearchTest(year, passed, vehicle);
+        testHistory.setTestType(testType);
+
+        return testHistory;
+    }
+
+    public static TestHistory getSearchTest(int year, boolean passed, uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle vehicle) {
+
+        TestHistory testHistory = new TestHistory();
+
+        switch (vehicle.getVehicleType()) {
+            case "HGV":
+                testHistory.setTestType("ANNUAL MV");
+                break;
+            case "PSV":
+                testHistory.setTestType("ANNUAL PSV LARGE");
+                break;
+            case "Trailer":
+                testHistory.setTestType("ANNUAL TRAILER");
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid vehicle type set: valid types are 'HGV', 'PSV' and 'Trailer'");
+        }
+
+        testHistory.setLocation("CHECK SITE 44272, STREET_NAME 44272, TOWN 44272, COUNTRY 44272, XY99 0ZZ");
+        testHistory.setTestResult(((passed) ? "Pass" : "Fail"));
+        testHistory.setTestDate("01/01/2019");
+        testHistory.setTestCertificateExpiryDateAtTest("01/01/2020");
+        testHistory.setTestCertificateSerialNo("GG000001");
+        testHistory.setVehicleIdentifierAtTest(vehicle.getVehicleIdentifier());
+
+        if (passed) {
+            testHistory.setNumberOfAdvisoryDefectsAtTest(0);
+            testHistory.setNumberOfDefectsAtTest(0);
+        } else {
+            testHistory.setNumberOfAdvisoryDefectsAtTest(0);
+            testHistory.setNumberOfDefectsAtTest(2);
+
+            List<Defect> defectList = new ArrayList<>();
+            defectList.add(getSearchDefect(38, "F"));
+            defectList.add(getSearchDefect(63, "A"));
+            testHistory.setTestHistoryDefects(defectList);
+        }
+
+        return testHistory;
+    }
+
+    private static Defect getSearchDefect(int failureItemNo, String severityCode) {
+
+        Defect defect = new Defect();
+
+        defect.setFailureItemNo(failureItemNo);
+        if (failureItemNo == 38) {
+            defect.setFailureReason("Service Brake Operation");
+        } else if (failureItemNo == 63) {
+            defect.setFailureReason("Lamps");
+        }
+
+        defect.setSeverityCode(severityCode);
+        switch (severityCode) {
+            case "F":
+                defect.setSeverityDescription("Failure");
+                break;
+            case "A":
+                defect.setSeverityDescription("Advisory");
+                break;
+            case "R":
+                defect.setSeverityDescription("Pass after rectification");
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid severity code set: valid codes are 'F', 'A' and 'R'");
+        }
+
+        return defect;
     }
 }

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/VehicleV5ResponseMapperTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/VehicleV5ResponseMapperTest.java
@@ -11,7 +11,6 @@ import uk.gov.dvsa.mot.trade.api.response.RfrAndAdvisoryV2Response;
 import uk.gov.dvsa.mot.trade.api.response.VehicleResponse;
 import uk.gov.dvsa.mot.trade.api.response.VehicleV4Response;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleTestTypeMapFilterTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleTestTypeMapFilterTest.java
@@ -1,0 +1,34 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import org.junit.Test;
+
+import uk.gov.dvsa.mot.trade.api.response.mapper.MockVehicleDataHelper;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class SearchVehicleTestTypeMapFilterTest {
+
+    @Test
+    public void vehicleTestsTypeNotWhitelistedAreOmitted() {
+
+        Vehicle vehicle = MockVehicleDataHelper.getSearchVehicle("HGV", false);
+
+        assertTrue(SearchVehicleTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getSearchTest(2000, true, vehicle, "ANNUAL MV")
+        ));
+
+        assertTrue(SearchVehicleTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getSearchTest(2000, true, vehicle, "PAID RETEST")
+        ));
+
+        assertFalse(SearchVehicleTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getSearchTest(2000, true, vehicle, "SOME OTHER TEST")
+        ));
+
+        assertFalse(SearchVehicleTestTypeMapFilter.canDisplayTest(
+                MockVehicleDataHelper.getSearchTest(2000, true, vehicle, "PAID")
+        ));
+    }
+}

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV6ResponseMapperTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV6ResponseMapperTest.java
@@ -1,0 +1,271 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.gov.dvsa.mot.trade.api.response.mapper.MockVehicleDataHelper;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestV1Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectV1Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleV1Response;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+public class SearchVehicleV6ResponseMapperTest {
+
+    private SearchVehicleV6ResponseMapper vehicleResponseMapper;
+
+    @Before
+    public void init() {
+        vehicleResponseMapper = new SearchVehicleV6ResponseMapper();
+    }
+
+    @Test
+    public void map_mapsAllPropertiesCorrectly() {
+        List<Vehicle> vehiclesFromDb = Arrays.asList(
+                MockVehicleDataHelper.getSearchVehicle("HGV", true),
+                MockVehicleDataHelper.getSearchVehicle("PSV", true),
+                MockVehicleDataHelper.getSearchVehicle("Trailer", false)
+        );
+
+        List<SearchVehicleResponse> mappedVehicles = vehicleResponseMapper.map(vehiclesFromDb);
+
+        assertVehiclesMapped(vehiclesFromDb, mappedVehicles);
+    }
+
+    @Test
+    public void ensureOnlyValidTestTypesAreMapped() {
+
+        List<Vehicle> vehicleList = Arrays.asList(
+                MockVehicleDataHelper.getSearchVehicleContainingSpecificTestType(
+                        "HGV", Arrays.asList("INVALIDTYPE", "ANNUAL MV")),
+                MockVehicleDataHelper.getSearchVehicleContainingSpecificTestType(
+                        "PSV", Arrays.asList("PAID RETEST", "1ST PAID RETEST", "NOPE", "ANNUAL PSV SMALL")),
+                MockVehicleDataHelper.getSearchVehicleContainingSpecificTestType(
+                        "Trailer", Arrays.asList("TRI AXLE FREE RETEST", "ANNUAL TRAILER"))
+        );
+
+        List<SearchVehicleResponse> mappedVehicles = vehicleResponseMapper.map(vehicleList);
+
+        assertEquals("Defined vehicle list size does not match response vehicle list size",
+                vehicleList.size(),
+                mappedVehicles.size()
+        );
+
+        // Assert we get the correct first vehicle of type HGV
+        SearchVehicleResponse vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("HGV"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of HGV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in HGV response test history",
+                1,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that HGV response vehicle contained ANNUAL MV",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL MV")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that HGV response vehicle did NOT contain INVALIDTYPE",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .noneMatch(t -> t.getTestType()
+                                .equals("INVALIDTYPE")
+                        )
+        );
+
+        // Assert we get the correct first vehicle of type PSV
+        vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("PSV"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of PSV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in PSV response test history",
+                3,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained PAID RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("PAID RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained 1ST PAID RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("1ST PAID RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained ANNUAL PSV SMALL",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL PSV SMALL")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle NOT contain INVALIDTYPE",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .noneMatch(t -> t.getTestType()
+                                .equals("NOPE")
+                        )
+        );
+
+        // Assert we get the correct first vehicle of type PSV
+        vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("Trailer"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of PSV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in PSV response test history",
+                2,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that Trailer response vehicle contained TRI AXLE FREE RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("TRI AXLE FREE RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that Trailer response vehicle contained ANNUAL TRAILER",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL TRAILER")
+                        )
+        );
+    }
+
+    private void assertVehiclesMapped(List<Vehicle> vehicles, List<SearchVehicleResponse> mappedVehicles) {
+        assertEquals(vehicles.size(), mappedVehicles.size());
+
+        for (int i = 0; i < vehicles.size(); i++) {
+            Vehicle vehicle = vehicles.get(i);
+            assertEquals(SearchVehicleV1Response.class, mappedVehicles.get(i).getClass());
+            SearchVehicleV1Response responseVehicle = (SearchVehicleV1Response) mappedVehicles.get(i);
+
+            assertEquals(vehicle.getVehicleIdentifier(), responseVehicle.getRegistration());
+            assertEquals(vehicle.getMake(), responseVehicle.getMake());
+            assertEquals(vehicle.getModel(), responseVehicle.getModel());
+            assertEquals(vehicle.getVehicleType(), responseVehicle.getVehicleType());
+            assertEquals(vehicle.getVehicleClass(), responseVehicle.getVehicleClass());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getRegistrationDate()),
+                    responseVehicle.getRegistrationDate()
+            );
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getManufactureDate()),
+                    responseVehicle.getManufactureDate()
+            );
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getTestCertificateExpiryDate()),
+                    responseVehicle.getAnnualTestExpiryDate()
+            );
+            assertAnnualTestMapped(vehicle.getTestHistory(), responseVehicle.getAnnualTests());
+        }
+    }
+
+    private void assertAnnualTestMapped(List<TestHistory> annualTests, List<AnnualTestResponse> mappedAnnualTests) {
+        if (annualTests == null) {
+            assertNull(mappedAnnualTests);
+            return;
+        }
+        assertEquals(annualTests.size(), mappedAnnualTests.size());
+
+        for (int i = 0; i < annualTests.size(); i++) {
+            TestHistory annualTest = annualTests.get(i);
+
+            assertEquals(AnnualTestV1Response.class, mappedAnnualTests.get(i).getClass());
+            AnnualTestV1Response responseTest = (AnnualTestV1Response) mappedAnnualTests.get(i);
+
+            assertEquals(annualTest.getTestType(), responseTest.getTestType());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(annualTest.getTestDate()),
+                    responseTest.getTestDate()
+            );
+            assertEquals(annualTest.getTestResult(), responseTest.getTestResult());
+            assertEquals(annualTest.getTestCertificateSerialNo(), responseTest.getTestCertificateNumber());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(annualTest.getTestCertificateExpiryDateAtTest()),
+                    responseTest.getExpiryDate()
+            );
+            assertEquals(annualTest.getNumberOfAdvisoryDefectsAtTest().toString(), responseTest.getNumberOfAdvisoryDefectsAtTest());
+            assertEquals(annualTest.getNumberOfDefectsAtTest().toString(), responseTest.getNumberOfDefectsAtTest());
+
+            assertDefectsMapped(annualTest.getTestHistoryDefects(), responseTest.getDefects());
+        }
+    }
+
+    private void assertDefectsMapped(List<Defect> defects, List<DefectResponse> mappedDefects) {
+        if (defects == null) {
+            assertNull(mappedDefects);
+            return;
+        }
+        assertEquals(defects.size(), mappedDefects.size());
+
+        for (int i = 0; i < defects.size(); i++) {
+            Defect defect = defects.get(i);
+
+            assertEquals(DefectV1Response.class, mappedDefects.get(i).getClass());
+            DefectV1Response responseDefect = (DefectV1Response) mappedDefects.get(i);
+
+            assertEquals(defect.getFailureItemNo().toString(), responseDefect.getFailureItemNo());
+            assertEquals(defect.getFailureReason(), responseDefect.getFailureReason());
+            assertEquals(defect.getSeverityCode(), responseDefect.getSeverityCode());
+            assertEquals(defect.getSeverityDescription(), responseDefect.getSeverityDescription());
+        }
+    }
+}

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/read/core/TradeAnnualTestsReadServiceTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/read/core/TradeAnnualTestsReadServiceTest.java
@@ -1,0 +1,184 @@
+package uk.gov.dvsa.mot.trade.read.core;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import uk.gov.dvsa.mot.trade.api.response.mapper.MockVehicleDataHelper;
+import uk.gov.dvsa.mot.vehicle.hgv.SearchVehicleProvider;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TradeAnnualTestsReadServiceTest {
+
+    private TradeAnnualTestsReadService tradeAnnualTestsReadService;
+
+    @Mock
+    SearchVehicleProvider searchVehicleProviderMock;
+
+    @Before
+    public void beforeTest() {
+        MockitoAnnotations.initMocks(this);
+        this.tradeAnnualTestsReadService = new TradeAnnualTestsReadService();
+        this.tradeAnnualTestsReadService.setSearchVehicleProvider(this.searchVehicleProviderMock);
+    }
+
+    @After
+    public void afterTest() {
+        this.tradeAnnualTestsReadService = null;
+    }
+
+    @Test
+    public void getAnnualTests_SingleRegistration() throws Exception {
+
+        HashSet<String> registrations = new HashSet<String>() {
+            {
+                add("ABC123");
+            }
+        };
+
+        for (String registration : registrations) {
+            Vehicle vehicle = MockVehicleDataHelper.getSearchVehicle("HGV", false);
+            vehicle.setVehicleIdentifier(registration);
+
+            when(searchVehicleProviderMock.getVehicle(registration)).thenReturn(vehicle);
+        }
+
+        List<Vehicle> vehiclesResponse = this.tradeAnnualTestsReadService.getAnnualTests(registrations);
+
+        for (String registration : registrations) {
+            verify(searchVehicleProviderMock).getVehicle(registration);
+
+            Optional<Vehicle> returnedVehicle = vehiclesResponse.stream().filter(
+                    v -> v.getVehicleIdentifier().equals(registration)
+            ).findFirst();
+
+            assertNotNull(returnedVehicle);
+
+            assertEquals(
+                    "The vehicle returned has the same VRM",
+                    registration,
+                    returnedVehicle.orElse(new Vehicle()).getVehicleIdentifier()
+            );
+        }
+
+        verify(searchVehicleProviderMock, times(1)).getVehicle(any());
+        assertEquals("We return one vehicle", 1, vehiclesResponse.size());
+    }
+
+    @Test
+    public void getAnnualTests_MultipleRegistrations() throws Exception {
+
+        HashSet<String> registrations = new HashSet<String>() {
+            {
+                add("ABC123");
+                add("CBA321");
+                add("BAC231");
+                add("ACB312");
+            }
+        };
+
+        for (String registration : registrations) {
+            Vehicle vehicle = MockVehicleDataHelper.getSearchVehicle("HGV", false);
+            vehicle.setVehicleIdentifier(registration);
+
+            when(searchVehicleProviderMock.getVehicle(registration)).thenReturn(vehicle);
+        }
+
+        List<Vehicle> vehiclesResponse = this.tradeAnnualTestsReadService.getAnnualTests(registrations);
+
+        for (String registration : registrations) {
+            verify(searchVehicleProviderMock).getVehicle(registration);
+
+            Optional<Vehicle> returnedVehicle = vehiclesResponse.stream().filter(
+                    v -> v.getVehicleIdentifier().equals(registration)
+            ).findFirst();
+
+            assertNotNull(returnedVehicle);
+
+            assertEquals(
+                    "The vehicle returned has the same VRM",
+                    registration,
+                    returnedVehicle.orElse(new Vehicle()).getVehicleIdentifier()
+            );
+        }
+
+        verify(searchVehicleProviderMock, times(4)).getVehicle(any());
+        assertEquals("We return all 4 vehicles", 4, vehiclesResponse.size());
+    }
+
+    @Test
+    public void getAnnualTests_EmptyRegistrationsAreIgnored() throws Exception {
+
+        HashSet<String> registrations = new HashSet<String>() {
+            {
+                add("ABC123");
+                add("");
+                add("CBA321");
+            }
+        };
+
+        for (String registration : registrations) {
+            Vehicle vehicle = MockVehicleDataHelper.getSearchVehicle("HGV", false);
+            vehicle.setVehicleIdentifier(registration);
+
+            when(searchVehicleProviderMock.getVehicle(registration)).thenReturn(vehicle);
+        }
+
+        List<Vehicle> vehiclesResponse = this.tradeAnnualTestsReadService.getAnnualTests(registrations);
+
+        for (String registration : registrations) {
+            if (!registration.equals("")) {
+                verify(searchVehicleProviderMock).getVehicle(registration);
+            }
+        }
+
+        verify(searchVehicleProviderMock, times(2)).getVehicle(any());
+        assertEquals("We return two vehicles only", 2, vehiclesResponse.size());
+    }
+
+    @Test
+    public void getAnnualTests_VehiclesNotFoundAreOmittedFromResultSet() throws Exception {
+
+        HashSet<String> registrations = new HashSet<String>() {
+            {
+                add("ABC123");
+                add("NOSUCH");
+                add("CBA321");
+                add("BCA131");
+            }
+        };
+
+        for (String registration : registrations) {
+            Vehicle vehicle = MockVehicleDataHelper.getSearchVehicle("HGV", false);
+            vehicle.setVehicleIdentifier(registration);
+
+            if (registration.equals("NOSUCH")) {
+                when(searchVehicleProviderMock.getVehicle(registration)).thenReturn(null);
+            } else {
+                when(searchVehicleProviderMock.getVehicle(registration)).thenReturn(vehicle);
+            }
+        }
+
+        List<Vehicle> vehiclesResponse = this.tradeAnnualTestsReadService.getAnnualTests(registrations);
+
+        for (String registration : registrations) {
+            verify(searchVehicleProviderMock).getVehicle(registration);
+        }
+
+        verify(searchVehicleProviderMock, times(4)).getVehicle(any());
+        assertEquals("We return three vehicles", 3, vehiclesResponse.size());
+    }
+}


### PR DESCRIPTION
This adds a new endpoint /trade/vehicles/annual-tests/ which accepts the parameter registrations which allows a user to search up-to a variable number of VRMs of HGV, PSVs and Trailers.

registrations should be entered as a comma separated list.

This new functionality is currently under trial.