### PR TITLE
Include location in the response when querying HGV annual tests

### DIFF
--- a/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/app/TradeServiceRequestHandler.java
@@ -47,9 +47,8 @@ import static uk.gov.dvsa.mot.app.ConfigManager.getEnvironmentVariable;
 
 /**
  * Entry point class for Lambdas.
- *
- * Various public methods in this class are called on Lambda invocation for
- * trade service queries.
+ * <p>
+ * Various public methods in this class are called on Lambda invocation for trade service queries.
  */
 @Path("/")
 public class TradeServiceRequestHandler extends AbstractRequestHandler {
@@ -72,8 +71,7 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
     }
 
     /**
-     * Set the read service which will be used to make queries required by this
-     * class.
+     * Set the read service which will be used to make queries required by this class.
      *
      * @param tradeReadService an instance of something which implements {@link TradeReadService}
      */
@@ -112,11 +110,11 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
     /**
      * Get MOT tests as per the provided request, grouped by vehicle.
      *
-     * @param vehicleId query parameter
-     * @param number query parameter
-     * @param registration query parameter
-     * @param motTestDate date query parameter
-     * @param page query parameter
+     * @param vehicleId      query parameter
+     * @param number         query parameter
+     * @param registration   query parameter
+     * @param motTestDate    date query parameter
+     * @param page           query parameter
      * @param requestContext AWS Lambda context object
      * @return A list of {@link Vehicle}, with each vehicle populated with its MOT tests matching the search parameters.
      * @throws TradeException Under various error conditions, including no tests found. It is expected that the surrounding integration will
@@ -224,14 +222,14 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
                 logger.trace("Exiting getTradeMotTests");
 
             } else if (page != null) {
-                logger.info("Trade API request for page = {}",  page);
+                logger.info("Trade API request for page = {}", page);
                 vehicles = tradeReadService.getVehiclesByPage(page);
 
                 if (CollectionUtils.isNullOrEmpty(vehicles)) {
                     throw new InvalidResourceException("No MOT Tests found for page: " + page.toString(), awsRequestId);
                 }
 
-                logger.debug("Trade API request for page = {} returned {} records",  page, vehicles.size());
+                logger.debug("Trade API request for page = {} returned {} records", page, vehicles.size());
                 logger.trace("Exiting getTradeMotTests");
 
             } else {
@@ -268,7 +266,9 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
     @Produces({
             MediaType.APPLICATION_JSON,
             MediaType.WILDCARD,
-            MediaType.APPLICATION_JSON + "+v6"})
+            MediaType.APPLICATION_JSON + "+v6",
+            MediaType.APPLICATION_JSON + "+v7"
+            })
     public Response getTradeAnnualTests(
             @QueryParam("registrations") String registrations,
             @javax.ws.rs.core.Context ContainerRequestContext requestContext
@@ -367,8 +367,8 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
     /**
      * Retrieve MOT tests in legacy format, based on the provided request.
      *
-     * @param registration a vehicle registration as a path parameter
-     * @param make a vehicle make as a path parameter.
+     * @param registration   a vehicle registration as a path parameter
+     * @param make           a vehicle make as a path parameter.
      * @param requestContext AWS Lambda request context
      * @return Response A list of MOTs in the legacy format.
      * @throws TradeException If there's an error retrieving data or a not-found condition.
@@ -435,9 +435,8 @@ public class TradeServiceRequestHandler extends AbstractRequestHandler {
     }
 
     /**
-     * This method accepts the query string of VRMs (separated by commas) and parses them into
-     * a trimmed set.
-     *
+     * This method accepts the query string of VRMs (separated by commas) and parses them into a trimmed set.
+     * <p>
      * Bonus of using {@link HashSet} is that it ensures no duplicate VRMs.
      *
      * @param registrations VRMs provided as a comma separated list

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapperFactory.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapperFactory.java
@@ -20,6 +20,9 @@ public class SearchVehicleResponseMapperFactory {
                 case "v6":
                     mapper = new SearchVehicleV6ResponseMapper();
                     break;
+                case "v7":
+                    mapper = new SearchVehicleV7ResponseMapper();
+                    break;
                 default:
                     logger.warn("Unknown API version selected. Using v6");
                     mapper = new SearchVehicleV6ResponseMapper();

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV7ResponseMapper.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV7ResponseMapper.java
@@ -1,0 +1,69 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import uk.gov.dvsa.mot.app.util.CollectionUtils;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestV2Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectV1Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleV1Response;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class SearchVehicleV7ResponseMapper extends SearchVehicleResponseMapper {
+
+    public List<SearchVehicleResponse> map(List<Vehicle> vehicles) {
+        return vehicles.stream().map(this::mapVehicle).collect(Collectors.toList());
+    }
+
+    private SearchVehicleResponse mapVehicle(Vehicle vehicle) {
+        SearchVehicleV1Response vehicleResponse = new SearchVehicleV1Response();
+        this.fillBaseVehicleResponseProperties(vehicleResponse, vehicle);
+        vehicleResponse.setAnnualTestExpiryDate(transformDate(vehicle.getTestCertificateExpiryDate()));
+
+        if (!CollectionUtils.isNullOrEmpty(vehicle.getTestHistory())) {
+            vehicleResponse.setAnnualTests(
+                    vehicle.getTestHistory()
+                            .stream()
+                            .map(this::mapTest)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList())
+            );
+        }
+
+        return vehicleResponse;
+    }
+
+    private AnnualTestResponse mapTest(TestHistory testHistory) {
+        if (!SearchVehicleTestTypeMapFilter.canDisplayTest(testHistory)) {
+            return null;
+        }
+
+        AnnualTestV2Response annualTestResponse = new AnnualTestV2Response();
+        this.fillBaseTestResponseProperties(annualTestResponse, testHistory);
+        annualTestResponse.setLocation(testHistory.getLocation());
+
+        if (!CollectionUtils.isNullOrEmpty(testHistory.getTestHistoryDefects())) {
+            annualTestResponse.setDefects(
+                    testHistory.getTestHistoryDefects().stream().map(this::mapDefect).collect(Collectors.toList())
+            );
+        }
+
+        return annualTestResponse;
+    }
+
+    private DefectResponse mapDefect(Defect defectItem) {
+        DefectV1Response defectResponse = new DefectV1Response();
+        defectResponse.setFailureItemNo(defectItem.getFailureItemNo());
+        defectResponse.setSeverityCode(defectItem.getSeverityCode());
+        defectResponse.setSeverityDescription(defectItem.getSeverityDescription());
+        defectResponse.setFailureReason(defectItem.getFailureReason());
+
+        return defectResponse;
+    }
+}

--- a/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/AnnualTestV2Response.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/trade/api/response/searchvehicle/AnnualTestV2Response.java
@@ -1,0 +1,16 @@
+package uk.gov.dvsa.mot.trade.api.response.searchvehicle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class AnnualTestV2Response extends AnnualTestResponse {
+    private String location;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapperFactoryTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleResponseMapperFactoryTest.java
@@ -1,0 +1,38 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(DataProviderRunner.class)
+public class SearchVehicleResponseMapperFactoryTest {
+
+    private SearchVehicleResponseMapperFactory factory;
+
+    @Before
+    public void init() {
+        factory = new SearchVehicleResponseMapperFactory();
+    }
+
+    @Test
+    @UseDataProvider("dataProviderForMapperVersions")
+    public void getMapper_CorrectlyInstantiatesMapperVersions(String requestedVersion, Class expectedMapper) {
+        assertEquals(expectedMapper, factory.getMapper(requestedVersion).getClass());
+    }
+
+    @DataProvider
+    public static Object[][] dataProviderForMapperVersions() {
+        return new Object[][]{
+                {"v6", SearchVehicleV6ResponseMapper.class},
+                {"v7", SearchVehicleV7ResponseMapper.class},
+                {"", SearchVehicleV6ResponseMapper.class},
+                {null, SearchVehicleV6ResponseMapper.class}
+        };
+    }
+}

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV7ResponseMapperTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/trade/api/response/mapper/searchvehicle/SearchVehicleV7ResponseMapperTest.java
@@ -1,0 +1,272 @@
+package uk.gov.dvsa.mot.trade.api.response.mapper.searchvehicle;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.gov.dvsa.mot.trade.api.response.mapper.MockVehicleDataHelper;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.AnnualTestV2Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.DefectV1Response;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleResponse;
+import uk.gov.dvsa.mot.trade.api.response.searchvehicle.SearchVehicleV1Response;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Defect;
+import uk.gov.dvsa.mot.vehicle.hgv.model.TestHistory;
+import uk.gov.dvsa.mot.vehicle.hgv.model.Vehicle;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+public class SearchVehicleV7ResponseMapperTest {
+
+    private SearchVehicleV7ResponseMapper vehicleResponseMapper;
+
+    @Before
+    public void init() {
+        vehicleResponseMapper = new SearchVehicleV7ResponseMapper();
+    }
+
+    @Test
+    public void map_mapsAllPropertiesCorrectly() {
+        List<Vehicle> vehiclesFromDb = Arrays.asList(
+                MockVehicleDataHelper.getSearchVehicle("HGV", true),
+                MockVehicleDataHelper.getSearchVehicle("PSV", true),
+                MockVehicleDataHelper.getSearchVehicle("Trailer", false)
+        );
+
+        List<SearchVehicleResponse> mappedVehicles = vehicleResponseMapper.map(vehiclesFromDb);
+
+        assertVehiclesMapped(vehiclesFromDb, mappedVehicles);
+    }
+
+    @Test
+    public void ensureOnlyValidTestTypesAreMapped() {
+
+        List<Vehicle> vehicleList = Arrays.asList(
+                MockVehicleDataHelper.getSearchVehicleContainingSpecificTestType(
+                        "HGV", Arrays.asList("INVALIDTYPE", "ANNUAL MV")),
+                MockVehicleDataHelper.getSearchVehicleContainingSpecificTestType(
+                        "PSV", Arrays.asList("PAID RETEST", "1ST PAID RETEST", "NOPE", "ANNUAL PSV SMALL")),
+                MockVehicleDataHelper.getSearchVehicleContainingSpecificTestType(
+                        "Trailer", Arrays.asList("TRI AXLE FREE RETEST", "ANNUAL TRAILER"))
+        );
+
+        List<SearchVehicleResponse> mappedVehicles = vehicleResponseMapper.map(vehicleList);
+
+        assertEquals("Defined vehicle list size does not match response vehicle list size",
+                vehicleList.size(),
+                mappedVehicles.size()
+        );
+
+        // Assert we get the correct first vehicle of type HGV
+        SearchVehicleResponse vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("HGV"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of HGV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in HGV response test history",
+                1,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that HGV response vehicle contained ANNUAL MV",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL MV")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that HGV response vehicle did NOT contain INVALIDTYPE",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .noneMatch(t -> t.getTestType()
+                                .equals("INVALIDTYPE")
+                        )
+        );
+
+        // Assert we get the correct first vehicle of type PSV
+        vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("PSV"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of PSV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in PSV response test history",
+                3,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained PAID RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("PAID RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained 1ST PAID RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("1ST PAID RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle contained ANNUAL PSV SMALL",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL PSV SMALL")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that PSV response vehicle NOT contain INVALIDTYPE",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .noneMatch(t -> t.getTestType()
+                                .equals("NOPE")
+                        )
+        );
+
+        // Assert we get the correct first vehicle of type PSV
+        vehicleResponse = mappedVehicles.stream()
+                .filter(v -> v.getVehicleType().equals("Trailer"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Expected vehicle type of PSV in response vehicle list",
+                vehicleResponse
+        );
+
+        assertEquals("Unexpected number of tests in PSV response test history",
+                2,
+                vehicleResponse.getAnnualTests().size()
+        );
+
+        assertTrue(
+                "Failed asserting that Trailer response vehicle contained TRI AXLE FREE RETEST",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("TRI AXLE FREE RETEST")
+                        )
+        );
+
+        assertTrue(
+                "Failed asserting that Trailer response vehicle contained ANNUAL TRAILER",
+                vehicleResponse
+                        .getAnnualTests()
+                        .stream()
+                        .anyMatch(t -> t.getTestType()
+                                .equals("ANNUAL TRAILER")
+                        )
+        );
+    }
+
+    private void assertVehiclesMapped(List<Vehicle> vehicles, List<SearchVehicleResponse> mappedVehicles) {
+        assertEquals(vehicles.size(), mappedVehicles.size());
+
+        for (int i = 0; i < vehicles.size(); i++) {
+            Vehicle vehicle = vehicles.get(i);
+            assertEquals(SearchVehicleV1Response.class, mappedVehicles.get(i).getClass());
+            SearchVehicleV1Response responseVehicle = (SearchVehicleV1Response) mappedVehicles.get(i);
+
+            assertEquals(vehicle.getVehicleIdentifier(), responseVehicle.getRegistration());
+            assertEquals(vehicle.getMake(), responseVehicle.getMake());
+            assertEquals(vehicle.getModel(), responseVehicle.getModel());
+            assertEquals(vehicle.getVehicleType(), responseVehicle.getVehicleType());
+            assertEquals(vehicle.getVehicleClass(), responseVehicle.getVehicleClass());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getRegistrationDate()),
+                    responseVehicle.getRegistrationDate()
+            );
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getManufactureDate()),
+                    responseVehicle.getManufactureDate()
+            );
+            assertEquals(
+                    vehicleResponseMapper.transformDate(vehicle.getTestCertificateExpiryDate()),
+                    responseVehicle.getAnnualTestExpiryDate()
+            );
+            assertAnnualTestMapped(vehicle.getTestHistory(), responseVehicle.getAnnualTests());
+        }
+    }
+
+    private void assertAnnualTestMapped(List<TestHistory> annualTests, List<AnnualTestResponse> mappedAnnualTests) {
+        if (annualTests == null) {
+            assertNull(mappedAnnualTests);
+            return;
+        }
+        assertEquals(annualTests.size(), mappedAnnualTests.size());
+
+        for (int i = 0; i < annualTests.size(); i++) {
+            TestHistory annualTest = annualTests.get(i);
+
+            assertEquals(AnnualTestV2Response.class, mappedAnnualTests.get(i).getClass());
+            AnnualTestV2Response responseTest = (AnnualTestV2Response) mappedAnnualTests.get(i);
+
+            assertEquals(annualTest.getLocation(), responseTest.getLocation());
+            assertEquals(annualTest.getTestType(), responseTest.getTestType());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(annualTest.getTestDate()),
+                    responseTest.getTestDate()
+            );
+            assertEquals(annualTest.getTestResult(), responseTest.getTestResult());
+            assertEquals(annualTest.getTestCertificateSerialNo(), responseTest.getTestCertificateNumber());
+            assertEquals(
+                    vehicleResponseMapper.transformDate(annualTest.getTestCertificateExpiryDateAtTest()),
+                    responseTest.getExpiryDate()
+            );
+            assertEquals(annualTest.getNumberOfAdvisoryDefectsAtTest().toString(), responseTest.getNumberOfAdvisoryDefectsAtTest());
+            assertEquals(annualTest.getNumberOfDefectsAtTest().toString(), responseTest.getNumberOfDefectsAtTest());
+
+            assertDefectsMapped(annualTest.getTestHistoryDefects(), responseTest.getDefects());
+        }
+    }
+
+    private void assertDefectsMapped(List<Defect> defects, List<DefectResponse> mappedDefects) {
+        if (defects == null) {
+            assertNull(mappedDefects);
+            return;
+        }
+        assertEquals(defects.size(), mappedDefects.size());
+
+        for (int i = 0; i < defects.size(); i++) {
+            Defect defect = defects.get(i);
+
+            assertEquals(DefectV1Response.class, mappedDefects.get(i).getClass());
+            DefectV1Response responseDefect = (DefectV1Response) mappedDefects.get(i);
+
+            assertEquals(defect.getFailureItemNo().toString(), responseDefect.getFailureItemNo());
+            assertEquals(defect.getFailureReason(), responseDefect.getFailureReason());
+            assertEquals(defect.getSeverityCode(), responseDefect.getSeverityCode());
+            assertEquals(defect.getSeverityDescription(), responseDefect.getSeverityDescription());
+        }
+    }
+}


### PR DESCRIPTION
Add location to annual test response
Introduce new v7 mapper
Make v7 mapper the default one