### PR TITLE
BL-17075: CVE-2015-7501 upgrade checkstyle to 6.19

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'checkstyle'
 
 checkstyle {
     configFile = getRootProject().file("dvsa_java_checks.xml")
-    toolVersion = "6.15"
+    toolVersion = "6.19"
 }
 
 sourceSets {

--- a/api/src/main/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProvider.java
+++ b/api/src/main/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProvider.java
@@ -82,7 +82,7 @@ public class MotrVehicleHistoryProvider {
     }
 
     @NotNull public VehicleWithLatestTest getDvlaVehicleWithTestByDvlaVehicleId(Integer dvlaVehicleId)
-    throws TradeException {
+        throws TradeException {
         Optional<VehicleWithLatestTest> vehicle = motrReadService.getLatestMotTestByDvlaVehicleId(dvlaVehicleId);
 
         return vehicle.orElseThrow(() ->
@@ -92,7 +92,7 @@ public class MotrVehicleHistoryProvider {
     }
 
     @NotNull public VehicleWithLatestTest getLatestMotTestByMotTestNumberWithSameRegistrationAndVin(Long motTestNumber)
-    throws TradeException {
+        throws TradeException {
         Optional<VehicleWithLatestTest> vehicle = motrReadService.getLatestMotTestByMotTestNumberWithSameRegistrationAndVin(motTestNumber);
         return vehicle.orElseThrow(() ->
             new InvalidResourceException(String.format("No MOT Tests found with number: %d", motTestNumber))

--- a/api/src/test/unit/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProviderTest.java
+++ b/api/src/test/unit/java/uk/gov/dvsa/mot/motr/service/MotrVehicleHistoryProviderTest.java
@@ -241,7 +241,7 @@ public class MotrVehicleHistoryProviderTest {
 
     @Test
     public void getDvlaVehicleWithTestByDvlaVehicleId_WhenMotrReadServiceReturnsNull_ShouldThrowException()
-    throws Exception {
+        throws Exception {
         when(motrReadService.getLatestMotTestByDvlaVehicleId(DVLA_VEHICLE_ID)).thenReturn(Optional.empty());
 
         catchException(motrVehicleHistoryProvider).getDvlaVehicleWithTestByDvlaVehicleId(DVLA_VEHICLE_ID);


### PR DESCRIPTION
## Description

Snyk detected CVE-2015-7501

```
  ✗ Deserialization of Untrusted Data [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078] in commons-collections:commons-collections@3.2.1
    introduced by com.puppycrawl.tools:checkstyle@6.15 > commons-beanutils:commons-beanutils@1.9.2 > commons-collections:commons-collections@3.2.1
  ✗ Deserialization of Untrusted Data [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-6056408] in commons-collections:commons-collections@3.2.1
    introduced by com.puppycrawl.tools:checkstyle@6.15 > commons-beanutils:commons-beanutils@1.9.2 > commons-collections:commons-collections@3.2.1
```

Resolved by upgrading checkstylefrom 6.15 to 6.19 and fixing any checkstyle errors 

Related issue: https://dvsa.atlassian.net/browse/BL-17075

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [X] Did you make sure to update any documentation relating to this change?
